### PR TITLE
Improvements to Rack JSON serialization

### DIFF
--- a/tuskar/api/controllers/v1.py
+++ b/tuskar/api/controllers/v1.py
@@ -194,6 +194,14 @@ class RacksController(rest.RestController):
 
         return result
 
+    @wsme_pecan.wsexpose(Rack, unicode)
+    def get_one(self, rack_id):
+        """Retrieve information about the given Rack."""
+        rack = pecan.request.dbapi.get_rack(rack_id)
+        link = _make_link('self', pecan.request.host_url, 'racks',
+                rack.id)
+        return Rack.from_db_and_links(rack, [link])
+
 
 class Controller(object):
     """Version 1 API controller root."""

--- a/tuskar/common/exception.py
+++ b/tuskar/common/exception.py
@@ -237,6 +237,10 @@ class BlaaNotFound(NotFound):
     message = _("Blaa %(blaa)s could not be found.")
 
 
+class RackNotFound(NotFound):
+    message = _("Rack %(rack)s could not be found.")
+
+
 class NodeLocked(NotFound):
     message = _("Node %(node)s is locked by another process.")
 

--- a/tuskar/db/sqlalchemy/api.py
+++ b/tuskar/db/sqlalchemy/api.py
@@ -79,6 +79,17 @@ class Connection(api.Connection):
                     subqueryload('capacities')
                 ).all()
 
+    def get_rack(self, rack_id):
+        session = get_session()
+        try:
+            result = session.query(models.Rack).options(
+                    subqueryload('capacities')
+                    ).filter_by(id=rack_id).one()
+        except NoResultFound:
+            raise exception.RackNotFound(rack=rack_id)
+
+        return result
+
     def create_rack(self, values):
         rack = models.Rack()
         # FIXME: This should be DB transaction ;-)

--- a/tuskar/db/sqlalchemy/models.py
+++ b/tuskar/db/sqlalchemy/models.py
@@ -76,9 +76,18 @@ class TuskarBase(models.TimestampMixin,
     metadata = None
 
     def as_dict(self):
-        d = {}
+        d = {"id": self['id']}
         for c in self.__table__.columns:
-            d[c.name] = self[c.name]
+            if c.name == 'id':
+                continue
+            if c.name.endswith('_url'):
+                d[c.name.replace('_url', '')] = {
+                        'links': [
+                                {"rel": "self", "url": self[c.name]}
+                            ]
+                        }
+            else:
+                d[c.name] = self[c.name]
         return d
 
 
@@ -130,6 +139,7 @@ class Rack(Base):
     name = Column(Text, unique=True)
     slots = Column(Integer)
     subnet = Column(String(length=64))
+    chassis_url = Column(Text)
     capacities = relationship("Capacity",
             secondary=Base.metadata.tables['rack_capacities'],
             lazy='joined')


### PR DESCRIPTION
This patch will add support for 'links' in JSON and properly format the 'chassis' attribute. The json response now looks like this (which is very close to what it should look like in the end):

``` json
    {
       "subnet": "192.168.1.0/255",
       "name": "my_rack_12",
       "links":
       [
           {
               "href": "http://0.0.0.0:6385/v1/racks/21",
               "rel": "self"
           }
       ],
       "capacities":
       [
           {
               "name": "total_cpu",
               "value": "64"
           },
           {
               "name": "total_memory",
               "value": "1024"
           }
       ],
       "chassis":
       {
           "links":
           [
               {
                   "url": "http://ironic.local:3333/v1/chassis/123",
                   "rel": "self"
               }
           ]
       },
       "slots": 1,
       "id": 21
    }
```
