### PR TITLE
Added Nodes list for Rack

### DIFF
--- a/etc/tuskar/tuskar.conf.sample
+++ b/etc/tuskar/tuskar.conf.sample
@@ -1,6 +1,12 @@
 [DEFAULT]
 
 #
+# Ironic API entrypoint URL (without trailing slash)
+#
+
+#ironic_url=http://ironic.local:6543/v1
+
+#
 # Options defined in tuskar.netconf
 #
 

--- a/tuskar/api/controllers/v1.py
+++ b/tuskar/api/controllers/v1.py
@@ -79,6 +79,11 @@ class Capacity(Base):
     name = wtypes.text
     value = wtypes.text
 
+class Hosts(Base):
+    """A Host list representation"""
+
+    links = [Link]
+
 
 class Rack(Base):
     """A representation of Rack in HTTP body"""
@@ -89,6 +94,7 @@ class Rack(Base):
     subnet = wtypes.text
     chassis = Chassis
     capacities = [Capacity]
+    hosts = Hosts
     links = [Link]
 
     @classmethod
@@ -97,11 +103,16 @@ class Rack(Base):
             chassis = Chassis(links=[Link(href=rack.chassis_url, rel="rack")])
         else:
             chassis = Chassis(links=[])
+
         capacities = [
-                Capacity(name=c.name, value=c.value) for c in rack.capacities
-                ]
+                       Capacity(name=c.name, value=c.value) for c in rack.capacities
+                     ]
+
+        hosts = Hosts(links=[ Link(href=h.node_url, rel="node") for h in
+            rack.hosts ])
+
         return Rack(links=links, chassis=chassis, capacities=capacities,
-                **(rack.as_dict()))
+                hosts=hosts, **(rack.as_dict()))
 
 class ResourceClass(Base):
     """A representation of Resource Class in HTTP body"""

--- a/tuskar/api/controllers/v1.py
+++ b/tuskar/api/controllers/v1.py
@@ -79,8 +79,8 @@ class Capacity(Base):
     name = wtypes.text
     value = wtypes.text
 
-class Hosts(Base):
-    """A Host list representation"""
+class Nodes(Base):
+    """A Node list representation"""
 
     links = [Link]
 
@@ -94,7 +94,7 @@ class Rack(Base):
     subnet = wtypes.text
     chassis = Chassis
     capacities = [Capacity]
-    hosts = Hosts
+    nodes = Nodes
     links = [Link]
 
     @classmethod
@@ -108,11 +108,11 @@ class Rack(Base):
                        Capacity(name=c.name, value=c.value) for c in rack.capacities
                      ]
 
-        hosts = Hosts(links=[ Link(href=h.node_url, rel="node") for h in
-            rack.hosts ])
+        nodes = Nodes(links=[ Link(href=h.node_url, rel="node") for h in
+            rack.nodes ])
 
         return Rack(links=links, chassis=chassis, capacities=capacities,
-                hosts=hosts, **(rack.as_dict()))
+                nodes=nodes, **(rack.as_dict()))
 
 class ResourceClass(Base):
     """A representation of Resource Class in HTTP body"""

--- a/tuskar/api/controllers/v1.py
+++ b/tuskar/api/controllers/v1.py
@@ -79,9 +79,10 @@ class Capacity(Base):
     name = wtypes.text
     value = wtypes.text
 
-class Nodes(Base):
-    """A Node list representation"""
+class Node(Base):
+    """A Node representation"""
 
+    id    = int
     links = [Link]
 
 
@@ -94,7 +95,7 @@ class Rack(Base):
     subnet = wtypes.text
     chassis = Chassis
     capacities = [Capacity]
-    nodes = Nodes
+    nodes = [Node]
     links = [Link]
 
     @classmethod
@@ -108,8 +109,7 @@ class Rack(Base):
                        Capacity(name=c.name, value=c.value) for c in rack.capacities
                      ]
 
-        nodes = Nodes(links=[ Link(href=h.node_url, rel="node") for h in
-            rack.nodes ])
+        nodes = [ Node(id=n.node_id) for n in rack.nodes ]
 
         return Rack(links=links, chassis=chassis, capacities=capacities,
                 nodes=nodes, **(rack.as_dict()))

--- a/tuskar/api/controllers/v1.py
+++ b/tuskar/api/controllers/v1.py
@@ -43,6 +43,9 @@ def _make_link(rel_name, url, type, type_arg):
     return Link(href=('%s/v1/%s/%s') % (url, type, type_arg),
                 rel=rel_name)
 
+def _ironic_link(rel_name, resource_id):
+    return Link(href=('%s/%s') % (CONF.ironic_url, resource_id), rel=rel_name)
+
 
 class Base(wtypes.Base):
 
@@ -79,6 +82,7 @@ class Link(Base):
 class Chassis(Base):
     """A chassis representation"""
 
+    id    = wtypes.text
     links = [Link]
 
 
@@ -91,7 +95,7 @@ class Capacity(Base):
 class Node(Base):
     """A Node representation"""
 
-    id    = int
+    id    = wtypes.text
     links = [Link]
 
 
@@ -109,19 +113,15 @@ class Rack(Base):
 
     @classmethod
     def convert_with_links(self, rack, links):
-        if rack.chassis_url:
-            chassis = Chassis(links=[Link(href=rack.chassis_url, rel="rack")])
+
+        if rack.chassis_id:
+            chassis = Chassis(id=rack.chassis_id, links=[_ironic_link('chassis', rack.chassis_id)])
         else:
-            chassis = Chassis(links=[])
+            chassis = Chassis()
 
-        capacities = [
-                       Capacity(name=c.name, value=c.value) for c in rack.capacities
-                     ]
+        capacities = [Capacity(name=c.name, value=c.value) for c in rack.capacities]
 
-        def node_link(node_id):
-            return Link(href=CONF.ironic_url + '/' + str(node_id), rel="node")
-
-        nodes = [ Node(id=n.node_id, links=[node_link(n.node_id)]) for n in rack.nodes ]
+        nodes = [Node(id=n.node_id, links=[_ironic_link('node', n.node_id)]) for n in rack.nodes]
 
         return Rack(links=links, chassis=chassis, capacities=capacities,
                 nodes=nodes, **(rack.as_dict()))
@@ -181,6 +181,11 @@ class RacksController(rest.RestController):
     @wsme_pecan.wsexpose(None, wtypes.text, status_code=204)
     def delete(self, rack_id):
         """Remove the Rack"""
+
+        # FIXME(mfojtik: For some reason, Pecan does not return 201 here
+        #                as configured above
+        #
+        pecan.response.status_code = 204
         pecan.request.dbapi.delete_rack(rack_id)
 
 class ResourceClassesController(rest.RestController):

--- a/tuskar/db/sqlalchemy/api.py
+++ b/tuskar/db/sqlalchemy/api.py
@@ -102,19 +102,26 @@ class Connection(api.Connection):
                      slots=new_rack.slots,
                      subnet=new_rack.subnet,
                    )
+
+            if new_rack.chassis:
+                rack.chassis_id=new_rack.chassis.id
+
             session.add(rack)
+
             if new_rack.capacities:
                 for c in new_rack.capacities:
                     capacity = models.Capacity(name=c.name, value=c.value)
                     session.add(capacity)
                     rack.capacities.append(capacity)
                     session.add(rack)
+
             if new_rack.nodes:
                 for n in new_rack.nodes:
                     node = models.Node(node_id=n.id)
                     session.add(node)
                     rack.nodes.append(node)
                     session.add(rack)
+
             session.commit()
             session.refresh(rack)
             return rack

--- a/tuskar/db/sqlalchemy/api.py
+++ b/tuskar/db/sqlalchemy/api.py
@@ -110,8 +110,8 @@ class Connection(api.Connection):
                     rack.capacities.append(capacity)
                     session.add(rack)
             if new_rack.nodes:
-                for link in new_rack.nodes.links:
-                    node = models.Node(node_url=link.href)
+                for n in new_rack.nodes:
+                    node = models.Node(node_id=n.id)
                     session.add(node)
                     rack.nodes.append(node)
                     session.add(rack)

--- a/tuskar/db/sqlalchemy/api.py
+++ b/tuskar/db/sqlalchemy/api.py
@@ -65,14 +65,16 @@ class Connection(api.Connection):
     def get_racks(self, columns):
         session = get_session()
         return session.query(models.Rack).options(
-                    subqueryload('capacities')
+                    subqueryload('capacities'),
+                    subqueryload('hosts')
                 ).all()
 
     def get_rack(self, rack_id):
         session = get_session()
         try:
             result = session.query(models.Rack).options(
-                    subqueryload('capacities')
+                    subqueryload('capacities'),
+                    subqueryload('hosts')
                     ).filter_by(id=rack_id).one()
         except NoResultFound:
             raise exception.RackNotFound(rack=rack_id)
@@ -99,7 +101,6 @@ class Connection(api.Connection):
                      name=new_rack.name,
                      slots=new_rack.slots,
                      subnet=new_rack.subnet,
-                     #chassis_url=new_rack.chassis.links[0].href
                    )
             session.add(rack)
             if new_rack.capacities:
@@ -107,6 +108,12 @@ class Connection(api.Connection):
                     capacity = models.Capacity(name=c.name, value=c.value)
                     session.add(capacity)
                     rack.capacities.append(capacity)
+                    session.add(rack)
+            if new_rack.hosts:
+                for link in new_rack.hosts.links:
+                    host = models.Host(node_url=link.href)
+                    session.add(host)
+                    rack.hosts.append(host)
                     session.add(rack)
             session.commit()
             session.refresh(rack)

--- a/tuskar/db/sqlalchemy/api.py
+++ b/tuskar/db/sqlalchemy/api.py
@@ -66,7 +66,7 @@ class Connection(api.Connection):
         session = get_session()
         return session.query(models.Rack).options(
                     subqueryload('capacities'),
-                    subqueryload('hosts')
+                    subqueryload('nodes')
                 ).all()
 
     def get_rack(self, rack_id):
@@ -74,7 +74,7 @@ class Connection(api.Connection):
         try:
             result = session.query(models.Rack).options(
                     subqueryload('capacities'),
-                    subqueryload('hosts')
+                    subqueryload('nodes')
                     ).filter_by(id=rack_id).one()
         except NoResultFound:
             raise exception.RackNotFound(rack=rack_id)
@@ -109,11 +109,11 @@ class Connection(api.Connection):
                     session.add(capacity)
                     rack.capacities.append(capacity)
                     session.add(rack)
-            if new_rack.hosts:
-                for link in new_rack.hosts.links:
-                    host = models.Host(node_url=link.href)
-                    session.add(host)
-                    rack.hosts.append(host)
+            if new_rack.nodes:
+                for link in new_rack.nodes.links:
+                    node = models.Node(node_url=link.href)
+                    session.add(node)
+                    rack.nodes.append(node)
                     session.add(rack)
             session.commit()
             session.refresh(rack)

--- a/tuskar/db/sqlalchemy/migrate_repo/versions/001_init.py
+++ b/tuskar/db/sqlalchemy/migrate_repo/versions/001_init.py
@@ -54,9 +54,9 @@ def upgrade(migrate_engine):
         mysql_charset=CHARSET,
     )
 
-    hosts = Table('hosts', meta,
+    nodes = Table('nodes', meta,
         Column('id', Integer, primary_key=True, nullable=False),
-        Column('node_url', Text),
+        Column('node_url', Text), # TODO(mfojtik): Probably rename this to just 'url' ;-)
         Column('rack_id', Integer, ForeignKey('racks.id')),
         Column('created_at', DateTime),
         Column('updated_at', DateTime),
@@ -84,7 +84,7 @@ def upgrade(migrate_engine):
         mysql_charset=CHARSET,
     )
 
-    tables = [capacities, racks, hosts, rack_capacities,
+    tables = [capacities, racks, nodes, rack_capacities,
               resource_classes]
 
     for table in tables:
@@ -102,8 +102,8 @@ def upgrade(migrate_engine):
         UniqueConstraint('name', table=racks,
                          name='racks_name_ux'),
 
-        UniqueConstraint('node_url', table=hosts,
-                         name='host_node_url_ux'),
+        UniqueConstraint('node_url', table=nodes,
+                         name='node_node_url_ux'),
     ]
 
     if migrate_engine.name == 'mysql' or migrate_engine.name == 'postgresql':

--- a/tuskar/db/sqlalchemy/migrate_repo/versions/001_init.py
+++ b/tuskar/db/sqlalchemy/migrate_repo/versions/001_init.py
@@ -56,7 +56,7 @@ def upgrade(migrate_engine):
 
     nodes = Table('nodes', meta,
         Column('id', Integer, primary_key=True, nullable=False),
-        Column('node_url', Text), # TODO(mfojtik): Probably rename this to just 'url' ;-)
+        Column('node_id', String(length=64)),
         Column('rack_id', Integer, ForeignKey('racks.id')),
         Column('created_at', DateTime),
         Column('updated_at', DateTime),
@@ -102,8 +102,11 @@ def upgrade(migrate_engine):
         UniqueConstraint('name', table=racks,
                          name='racks_name_ux'),
 
-        UniqueConstraint('node_url', table=nodes,
-                         name='node_node_url_ux'),
+        # The 'node_id' in nodes table must be unique
+        # so Tuskar Node <-> Ironic Node mapping is 1:1
+        #
+        UniqueConstraint('node_id', table=nodes,
+                         name='node_node_id_ux'),
     ]
 
     if migrate_engine.name == 'mysql' or migrate_engine.name == 'postgresql':

--- a/tuskar/db/sqlalchemy/migrate_repo/versions/001_init.py
+++ b/tuskar/db/sqlalchemy/migrate_repo/versions/001_init.py
@@ -47,7 +47,7 @@ def upgrade(migrate_engine):
         Column('name', String(length=128)),
         Column('slots', Integer),
         Column('subnet', String(length=128)),
-        Column('chassis_url', Text),
+        Column('chassis_id', String(length=64)),
         Column('created_at', DateTime),
         Column('updated_at', DateTime),
         mysql_engine=ENGINE,

--- a/tuskar/db/sqlalchemy/migrate_repo/versions/001_init.py
+++ b/tuskar/db/sqlalchemy/migrate_repo/versions/001_init.py
@@ -54,6 +54,16 @@ def upgrade(migrate_engine):
         mysql_charset=CHARSET,
     )
 
+    hosts = Table('hosts', meta,
+        Column('id', Integer, primary_key=True, nullable=False),
+        Column('node_url', Text),
+        Column('rack_id', Integer, ForeignKey('racks.id')),
+        Column('created_at', DateTime),
+        Column('updated_at', DateTime),
+        mysql_engine=ENGINE,
+        mysql_charset=CHARSET,
+    )
+
     rack_capacities = Table('rack_capacities', meta,
         Column('id', Integer, primary_key=True, nullable=False),
         Column('capacity_id', Integer, ForeignKey('capacities.id')),
@@ -74,7 +84,7 @@ def upgrade(migrate_engine):
         mysql_charset=CHARSET,
     )
 
-    tables = [capacities, racks, rack_capacities,
+    tables = [capacities, racks, hosts, rack_capacities,
               resource_classes]
 
     for table in tables:
@@ -91,6 +101,9 @@ def upgrade(migrate_engine):
     uniques = [
         UniqueConstraint('name', table=racks,
                          name='racks_name_ux'),
+
+        UniqueConstraint('node_url', table=hosts,
+                         name='host_node_url_ux'),
     ]
 
     if migrate_engine.name == 'mysql' or migrate_engine.name == 'postgresql':

--- a/tuskar/db/sqlalchemy/models.py
+++ b/tuskar/db/sqlalchemy/models.py
@@ -104,10 +104,10 @@ class RackCapacities(Base):
     capacity_id = Column(Integer, ForeignKey('capacities.id'),
             primary_key=True)
 
-class Host(Base):
-    """Represents a Host """
+class Node(Base):
+    """Represents a Node """
 
-    __tablename__ = 'hosts'
+    __tablename__ = 'nodes'
     id = Column(Integer, primary_key=True)
     rack_id = Column(Integer, ForeignKey('racks.id'))
     node_url = Column(Text, unique=True)
@@ -126,7 +126,7 @@ class Rack(Base):
             secondary=Base.metadata.tables['rack_capacities'],
             cascade="all, delete",
             lazy='joined')
-    hosts = relationship("Host", cascade="all, delete")
+    nodes = relationship("Node", cascade="all, delete")
 
 class ResourceClass(Base):
     """Represents a Resource Class."""

--- a/tuskar/db/sqlalchemy/models.py
+++ b/tuskar/db/sqlalchemy/models.py
@@ -121,7 +121,7 @@ class Rack(Base):
     name = Column(Text, unique=True)
     slots = Column(Integer)
     subnet = Column(String(length=64))
-    chassis_url = Column(Text)
+    chassis_id = Column(String(length=64))
     capacities = relationship("Capacity",
             secondary=Base.metadata.tables['rack_capacities'],
             cascade="all, delete",

--- a/tuskar/db/sqlalchemy/models.py
+++ b/tuskar/db/sqlalchemy/models.py
@@ -104,6 +104,14 @@ class RackCapacities(Base):
     capacity_id = Column(Integer, ForeignKey('capacities.id'),
             primary_key=True)
 
+class Host(Base):
+    """Represents a Host """
+
+    __tablename__ = 'hosts'
+    id = Column(Integer, primary_key=True)
+    rack_id = Column(Integer, ForeignKey('racks.id'))
+    node_url = Column(Text, unique=True)
+
 
 class Rack(Base):
     """Represents a Rack."""
@@ -118,6 +126,7 @@ class Rack(Base):
             secondary=Base.metadata.tables['rack_capacities'],
             cascade="all, delete",
             lazy='joined')
+    hosts = relationship("Host", cascade="all, delete")
 
 class ResourceClass(Base):
     """Represents a Resource Class."""

--- a/tuskar/db/sqlalchemy/models.py
+++ b/tuskar/db/sqlalchemy/models.py
@@ -110,7 +110,7 @@ class Node(Base):
     __tablename__ = 'nodes'
     id = Column(Integer, primary_key=True)
     rack_id = Column(Integer, ForeignKey('racks.id'))
-    node_url = Column(Text, unique=True)
+    node_id = Column(String(length=64), unique=True)
 
 
 class Rack(Base):


### PR DESCRIPTION
This patch adds several things:
- Add 'Node' database model
- Add 1-m relation between Rack->Node
- Add 'Node' representation in controller
- Support creating Rack with list of initial Nodes

Example:

Create Rack with Hosts:

``` bash
$ curl -X POST -H 'Content-Type: application/json' -H 'Accept: application/json' -v -d '{"subnet":"192.168.1.0/255","name":"my_rack","capacities":[{"name":"total_cpu","value":"64"},{"name":"total_memory","value":"1024"}],"nodes":{"links":[{"href":"http://ironic.local:3333/v1/node/123","rel":"node"},{"href":"http://ironic.local:3333/v1/node/456","rel":"node"}]},"slots":1}' http://0.0.0.0:6385/v1/racks
```

FYI, the uncompressed JSON looks like this:

``` json
{
   "subnet":"192.168.1.0/255",
   "name":"my_rack",
   "capacities":[
      {
         "name":"total_cpu",
         "value":"64"
      },
      {
         "name":"total_memory",
         "value":"1024"
      }
   ],
   "nodes":{
      "links":[
         {
            "href":"http://ironic.local:3333/v1/node/123",
            "rel":"node"
         },
         {
            "href":"http://ironic.local:3333/v1/node/456",
            "rel":"node"
         }
      ]
   },
   "slots":1
}
```
