### PR TITLE
Initial support for updating the Rack resource

### DIFF
--- a/tuskar/api/controllers/v1.py
+++ b/tuskar/api/controllers/v1.py
@@ -187,6 +187,21 @@ class RacksController(rest.RestController):
         pecan.response.status_code = 201
         return Rack.convert_with_links(result, links)
 
+    @wsme.validate(Rack)
+    @wsme_pecan.wsexpose(Rack, body=Rack, status_code=200)
+    def put(self, rack):
+        """Update the Rack"""
+
+        try:
+            result = pecan.request.dbapi.update_rack(rack)
+            links = [_make_link('self', pecan.request.host_url, 'racks',
+                    result.id)]
+        except Exception as e:
+            LOG.exception(e)
+            raise wsme.exc.ClientSideError(_("Invalid data"))
+        return Rack.convert_with_links(result, links)
+
+
     @wsme_pecan.wsexpose([Rack])
     def get_all(self):
         """Retrieve a list of all racks"""


### PR DESCRIPTION
Hi,

This patch add initial support for updating the Rack resource through REST interface. The syntax is following:

``` bash
$ curl -X PATCH -H 'Accept: application/json' -H 'Content-Type: application/json' \
  -d '{"id": "1", "name": "new-rack-name"}' http://0.0.0.0:6385/v1/racks
```

It is also possible to update 'capacities' and 'nodes'. Note, as this is a HTTP PUT operation, specifying the 'capacities' or 'nodes' will **always** replace the old list of capacities and nodes:

``` bash
$ curl -X PATCH -H 'Accept: application/json' -H 'Content-Type: application/json' \
  -d '{"id": "1", "capacities":[]}' http://0.0.0.0:6385/v1/racks
```

This will remove all capacities currently associated with given Rack.

``` bash
$ curl -X PATCH -H 'Accept: application/json' -H 'Content-Type: application/json' \
  -d '{"id": "1"}' http://0.0.0.0:6385/v1/racks
```

If 'capacities' or 'nodes' are omitted from the JSON body, they are ignored

Updating list of Nodes in Rack:

``` bash
$ curl -X PATCH -H 'Accept: application/json' -H 'Content-Type: application/json' \
  -d '{"id": "1", "nodes": [ { "id": "123"},  {"id": "345"} ]}' http://0.0.0.0:6385/v1/racks
```
