### PR TITLE
Updated Resource Class API

### DIFF
--- a/tuskar/api/controllers/v1.py
+++ b/tuskar/api/controllers/v1.py
@@ -68,6 +68,11 @@ class Base(wtypes.Base):
                 if hasattr(self, k) and
                 getattr(self, k) != wsme.Unset)
 
+    def get_id(self):
+        """Returns the ID of this resource as specified in the self link"""
+
+        # FIXME(mtaylor) We should use a more robust method for parsing the URL
+        return self.links[0].href.split("/")[-1]
 
 class Link(Base):
     """A link representation"""
@@ -126,13 +131,36 @@ class Rack(Base):
         return Rack(links=links, chassis=chassis, capacities=capacities,
                 nodes=nodes, **(rack.as_dict()))
 
+    @classmethod
+    def convert(self, rack, base_url, minimal=False):
+        links = [_make_link('self', pecan.request.host_url, 'rack',
+                             rack.id)]
+        if minimal:
+            return Rack(links=links, id=str(rack.id))
+
 class ResourceClass(Base):
     """A representation of Resource Class in HTTP body"""
 
     id = int
     name = wtypes.text
     service_type = wtypes.text
+    racks = [Rack]
+    links = [Link]
 
+    @classmethod
+    def convert(self, resource_class, base_url, minimal=False):
+        links = [_make_link('self', pecan.request.host_url, 'resource_classes',
+                             resource_class.id)]
+        if minimal:
+            return ResourceClass(links=links, id=str(resource_class.id))
+        else:
+            racks = []
+            if resource_class.racks:
+                for r in resource_class.racks:
+                    rack = Rack.convert(r, base_url, True)
+                    racks.append(rack)
+            return ResourceClass(links=links, racks=racks,
+                                 **(resource_class.as_dict()))
 
 class RacksController(rest.RestController):
     """REST controller for Rack"""
@@ -196,19 +224,45 @@ class ResourceClassesController(rest.RestController):
     def post(self, resource_class):
         """Create a new Resource Class."""
         try:
-            rc = ResourceClass(name=resource_class.name,
-                               service_type=resource_class.service_type)
-            result = pecan.request.dbapi.create_resource_class(rc.as_dict())
+            result = pecan.request.dbapi.create_resource_class(resource_class)
         except Exception as e:
             LOG.exception(e)
             raise wsme.exc.ClientSideError(_("Invalid data"))
-        return ResourceClass.from_db_model(result)
+
+        # 201 Created require Location header pointing to newly created
+        #     resource
+        #
+        # FIXME(mfojtik): For some reason, Pecan does not return 201 here
+        #                 as configured above
+        #
+        rc = ResourceClass.convert(result, pecan.request.host_url)
+        pecan.response.headers['Location'] = str(rc.links[0].href)
+        pecan.response.status_code = 201
+        return rc
+
 
     @wsme_pecan.wsexpose([ResourceClass])
     def get_all(self):
-        """Retrieve a list of all resource classes"""
-        result = pecan.request.dbapi.get_resource_classes(None)
-        return [ResourceClass.from_db_model(resource_class) for resource_class in result]
+        """Retrieve a list of all Resource Classes"""
+        result = []
+        for rc in pecan.request.dbapi.get_resource_classes(None):
+            result.append(ResourceClass.convert(rc, pecan.request.host_url))
+        return result
+
+
+    @wsme_pecan.wsexpose(ResourceClass, unicode)
+    def get_one(self, resource_class_id):
+        """Retrieve information about the given Resource Class."""
+        resource_class = pecan.request.dbapi.get_resource_class(resource_class_id)
+        links = [_make_link('self', pecan.request.host_url, 'resource_classes',
+                resource_class.id)]
+        return ResourceClass.convert(resource_class, pecan.request.host_url)
+
+
+    @wsme_pecan.wsexpose(None, wtypes.text, status_code=204)
+    def delete(self, resource_class_id):
+        """Remove the Resource Class"""
+        pecan.request.dbapi.delete_resource_class(resource_class_id)
 
 class Controller(object):
     """Version 1 API controller root."""

--- a/tuskar/db/sqlalchemy/api.py
+++ b/tuskar/db/sqlalchemy/api.py
@@ -81,17 +81,48 @@ class Connection(api.Connection):
 
         return result
 
+    def get_racks_by_resource_class(self, resource_class_id):
+        session = get_session()
+        return session.query(models.Rack
+                            ).filter_by(resource_class_id=resource_class_id
+                            ).all()
+
     def get_resource_classes(self, columns):
         session = get_session()
         return session.query(models.ResourceClass).all()
 
-    def create_resource_class(self, values):
-        rc = models.ResourceClass()
-        # FIXME: This should be DB transaction ;-)
-        #
-        rc.update(values)
-        rc.save()
+    def get_resource_class(self, resource_class_id):
+        session = get_session()
+        try:
+            result = session.query(models.ResourceClass
+                                ).filter_by(id=resource_class_id).one()
+        except NoResultFound:
+            raise exception.ResourceClassNotFound(resource_class=resource_class_id)
+
+        return result
+
+    def create_resource_class(self, new_resource_class):
+        session = get_session()
+        session.begin()
+        try:
+            rc = models.ResourceClass(name=new_resource_class.name,
+                                      service_type=new_resource_class.service_type)
+            session.add(rc)
+            if new_resource_class.racks:
+                racks = []
+                for r in new_resource_class.racks:
+                    # FIXME surely there is a better way of doing this.
+                    rack = self.get_rack(r.get_id())
+                    session.add(rack)
+                    rack.resource_class = rc
+        except:
+            session.rollback()
+            raise
+
+        session.commit()
+        session.refresh(rc)
         return rc
+
 
     def create_rack(self, new_rack):
         session = get_session()
@@ -137,6 +168,19 @@ class Connection(api.Connection):
             session.delete(rack)
             for c in rack.capacities:
                 session.delete(c)
+            session.commit()
+        except:
+            session.rollback()
+            raise
+
+    def delete_resource_class(self, resource_class_id):
+        session = get_session()
+        session.begin()
+        try:
+            # FIXME (mtaylor) we should also set the foreign key to None for
+            # all associated Racks
+            session.query(models.ResourceClass
+                          ).filter_by(id=resource_class_id).delete()
             session.commit()
         except:
             session.rollback()

--- a/tuskar/db/sqlalchemy/migrate_repo/versions/001_init.py
+++ b/tuskar/db/sqlalchemy/migrate_repo/versions/001_init.py
@@ -47,6 +47,7 @@ def upgrade(migrate_engine):
         Column('name', String(length=128)),
         Column('slots', Integer),
         Column('subnet', String(length=128)),
+        Column('resource_class_id', Integer, ForeignKey('resource_classes.id')),
         Column('chassis_id', String(length=64)),
         Column('created_at', DateTime),
         Column('updated_at', DateTime),

--- a/tuskar/db/sqlalchemy/models.py
+++ b/tuskar/db/sqlalchemy/models.py
@@ -122,11 +122,13 @@ class Rack(Base):
     slots = Column(Integer)
     subnet = Column(String(length=64))
     chassis_id = Column(String(length=64))
+    resource_class_id = Column(Integer, ForeignKey('resource_classes.id'))
     capacities = relationship("Capacity",
             secondary=Base.metadata.tables['rack_capacities'],
             cascade="all, delete",
             lazy='joined')
     nodes = relationship("Node", cascade="all, delete")
+
 
 class ResourceClass(Base):
     """Represents a Resource Class."""
@@ -135,7 +137,7 @@ class ResourceClass(Base):
     id = Column(Integer, primary_key=True)
     name = Column(Text, unique=True)
     service_type = Column(Text, unique=True)
-
-    def as_dict(self):
-        d = super(ResourceClass, self).as_dict()
-        return d
+    racks = relationship("Rack",
+                         backref="resource_class",
+                         lazy='joined',
+                         cascade="all")


### PR DESCRIPTION
Add transactions to the database operations
Add GET and DELETE operations
Support association of Racks in POST operation
Starts work on nested marshalling

To create a new resource class with associated Rack, first create a Rack

POST /racks

```
    {
       "subnet": "192.168.1.0/255",
       "name": "my_rack_12",
       "capacities":
       [
           {
               "name": "total_cpu",
               "value": "64"
           },
           {
               "name": "total_memory",
               "value": "1024"
           }
       ],
       "chassis":
       {
           "links":
           [
               {
                   "url": "http://ironic.local:3333/v1/chassis/123",
                   "rel": "self"
               }
           ]
       },
       "slots": 1
    }

```

Next create a Resource Class and reference the URL returned from the POST /racks request

POST resource_classes

```
{
    "service_type": "compute",
    "name": "test-chassis",
    "racks":[
      {
        "links": [
          { "href":"http://0.0.0.0:6385/v1/racks/6", "rel":"self" }
        ]
      }
    ]
}


```
