### PR TITLE
Add entry points to the API

### DIFF
--- a/tuskar/api/controllers/root.py
+++ b/tuskar/api/controllers/root.py
@@ -25,7 +25,18 @@ class RootController(object):
 
     v1 = v1.Controller()
 
-    @pecan.expose(generic=True)
+    @pecan.expose('json')
     def index(self):
-        # FIXME: GET / should return more than just ''
-        return ''
+        return {
+            'versions': {
+                'values': [{
+                    'status': 'development',
+                    'media-types': [ {'base': 'application/json'} ],
+                    'id': 'v1.0',
+                    'links': [{
+                        'href': '/v1/',
+                        'rel': 'self',
+                    }]
+                }]
+            }
+        }

--- a/tuskar/api/controllers/v1.py
+++ b/tuskar/api/controllers/v1.py
@@ -216,3 +216,17 @@ class Controller(object):
     racks = RacksController()
 
     resource_classes = ResourceClassesController()
+
+    @pecan.expose('json')
+    def index(self):
+        return {
+            'version': {
+                'status': 'stable',
+                'media-types': [ {'base': 'application/json'} ],
+                'id': 'v1.0',
+                'links': [{
+                    'href': '/v1/',
+                    'rel': 'self',
+                }]
+            }
+        }


### PR DESCRIPTION
GET / and GET /v1/ now return basic metadata. The look and feel is
in line with the other OpenStack APIs, albeit more spare.

Signed-off-by: Tomas Sedovic tomas@sedovic.cz
