### PR TITLE
Fix rack update support

### DIFF
--- a/tuskar/api/controllers/v1.py
+++ b/tuskar/api/controllers/v1.py
@@ -208,12 +208,12 @@ class RacksController(rest.RestController):
         return Rack.convert_with_links(result, links)
 
     @wsme.validate(Rack)
-    @wsme_pecan.wsexpose(Rack, body=Rack, status_code=200)
-    def put(self, rack):
+    @wsme_pecan.wsexpose(Rack, wtypes.text, body=Rack, status_code=200)
+    def put(self, rack_id, rack):
         """Update the Rack"""
 
         try:
-            result = pecan.request.dbapi.update_rack(rack)
+            result = pecan.request.dbapi.update_rack(rack_id, rack)
             links = [_make_link('self', pecan.request.host_url, 'racks',
                     result.id)]
         except Exception as e:

--- a/tuskar/db/sqlalchemy/api.py
+++ b/tuskar/db/sqlalchemy/api.py
@@ -125,11 +125,11 @@ class Connection(api.Connection):
         session.refresh(rc)
         return rc
 
-    def update_rack(self, new_rack):
+    def update_rack(self, rack_id, new_rack):
         session = get_session()
         session.begin()
         try:
-            rack = self.get_rack(new_rack.id)
+            rack = self.get_rack(rack_id)
 
             # FIXME(mfojtik): The update below is a bit retar*ed,
             # There must be a better way how to do 'update' in sqlalchemy.


### PR DESCRIPTION
Currently, you must do:

  curl -X PUT -H 'Accept: application/json' \
              -H 'Content-Type: application/json' \
       -d '{"id: "1", "name": "new-name"}' http://0.0.0.0:6385/v1/racks

but PUT should be on the entity URL itself:

  curl -X PUT -H 'Accept: application/json' \
              -H 'Content-Type: application/json' \
       -d '{"name": "new-name"}' http://0.0.0.0:6385/v1/racks/1
