### PR TITLE
Initial addition of the test for V1 controller

### DIFF
--- a/tuskar/tests/api.py
+++ b/tuskar/tests/api.py
@@ -1,0 +1,126 @@
+# -*- encoding: utf-8 -*-
+#
+# Copyright © 2012 New Dream Network, LLC (DreamHost)
+#
+# Author: Doug Hellmann <doug.hellmann@dreamhost.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+"""Base classes for API tests.
+"""
+
+import urllib
+from oslo.config import cfg
+
+import pecan
+import pecan.testing
+
+from tuskar.openstack.common import jsonutils
+from tuskar.api import acl
+from tuskar.tests import base
+
+
+class FunctionalTest(base.TestCase):
+    """Used for functional tests of Pecan controllers where you need to
+    test your literal application and its integration with the
+    framework.
+    """
+
+    PATH_PREFIX = '/v1'
+
+    SOURCE_DATA = {'test_source': {'somekey': '666'}}
+
+    def setUp(self):
+        super(FunctionalTest, self).setUp()
+        cfg.CONF.set_override("auth_version", "v2.0", group=acl.OPT_GROUP_NAME)
+        cfg.CONF.set_override("policy_file",
+                              self.path_get('tests/policy.json'))
+        self.app = self._make_app()
+
+    def _make_app(self, enable_acl=False):
+        # Determine where we are so we can set up paths in the config
+        root_dir = self.path_get()
+
+        self.config = {
+            'app': {
+                'root': 'tuskar.api.controllers.root.RootController',
+                'modules': ['tuskar.api'],
+                'static_root': '%s/public' % root_dir,
+                'template_path': '%s/tuskar/api/templates' % root_dir,
+                'enable_acl': enable_acl,
+            },
+        }
+
+        return pecan.testing.load_test_app(self.config)
+
+    def tearDown(self):
+        super(FunctionalTest, self).tearDown()
+        pecan.set_config({}, overwrite=True)
+
+    def put_json(self, path, params, expect_errors=False, headers=None,
+                 extra_environ=None, status=None):
+        return self.post_json(path=path, params=params,
+                              expect_errors=expect_errors,
+                              headers=headers, extra_environ=extra_environ,
+                              status=status, method="put")
+
+    def post_json(self, path, params, expect_errors=False, headers=None,
+                  method="post", extra_environ=None, status=None):
+        full_path = self.PATH_PREFIX + path
+        print('%s: %s %s' % (method.upper(), full_path, params))
+        response = getattr(self.app, "%s_json" % method)(
+            str(full_path),
+            params=params,
+            headers=headers,
+            status=status,
+            extra_environ=extra_environ,
+            expect_errors=expect_errors
+        )
+        print('GOT:%s' % response)
+        return response
+
+    def delete(self, path, expect_errors=False, headers=None,
+               extra_environ=None, status=None):
+        full_path = self.PATH_PREFIX + path
+        print('DELETE: %s' % (full_path))
+        response = self.app.delete(str(full_path),
+                                   headers=headers,
+                                   status=status,
+                                   extra_environ=extra_environ,
+                                   expect_errors=expect_errors)
+        print('GOT:%s' % response)
+        return response
+
+    def get_json(self, path, expect_errors=False, headers=None,
+                 extra_environ=None, q=[], **params):
+        full_path = self.PATH_PREFIX + path
+        query_params = {'q.field': [],
+                        'q.value': [],
+                        'q.op': [],
+                        }
+        for query in q:
+            for name in ['field', 'op', 'value']:
+                query_params['q.%s' % name].append(query.get(name, ''))
+        all_params = {}
+        all_params.update(params)
+        if q:
+            all_params.update(query_params)
+        print('GET: %s %r' % (full_path, all_params))
+        response = self.app.get(full_path,
+                                params=all_params,
+                                headers=headers,
+                                extra_environ=extra_environ,
+                                expect_errors=expect_errors)
+        if not expect_errors:
+            response = response.json
+        print('GOT:%s' % response)
+        return response

--- a/tuskar/tests/api.py
+++ b/tuskar/tests/api.py
@@ -73,6 +73,13 @@ class FunctionalTest(base.TestCase):
                               headers=headers, extra_environ=extra_environ,
                               status=status, method="put")
 
+    def delete_json(self, path, expect_errors=False, headers=None,
+                 extra_environ=None, status=None):
+        return self.post_json(path=path, params={},
+                              expect_errors=expect_errors,
+                              headers=headers, extra_environ=extra_environ,
+                              status=status, method="delete")
+
     def post_json(self, path, params, expect_errors=False, headers=None,
                   method="post", extra_environ=None, status=None):
         full_path = self.PATH_PREFIX + path

--- a/tuskar/tests/base.py
+++ b/tuskar/tests/base.py
@@ -203,6 +203,17 @@ class TestCase(testtools.TestCase):
         for k, v in kw.iteritems():
             CONF.set_override(k, v, group)
 
+    def path_get(self, project_file=None):
+        root = os.path.abspath(os.path.join(os.path.dirname(__file__),
+            '..',
+            '..',
+            )
+            )
+        if project_file:
+            return os.path.join(root, project_file)
+        else:
+            return root
+
 
 class TimeOverride(fixtures.Fixture):
     """Fixture to start and remove time override."""

--- a/tuskar/tests/test_v1.py
+++ b/tuskar/tests/test_v1.py
@@ -1,0 +1,31 @@
+"""Base classes for API tests.
+"""
+
+import os
+from oslo.config import cfg
+from tuskar.api import app
+from tuskar.tests import base
+from tuskar.api import acl
+from tuskar.tests import api
+
+
+class TestRacks(api.FunctionalTest):
+
+
+    def test_it_returns_valid_404(self):
+        response = self.get_json('/invalid_path',
+                expect_errors=True,
+                headers={"Accept":
+                    "application/json"}
+                )
+
+        self.assertEqual(response.status_int, 404)
+
+    def test_it_returns_404_for_unknown_rack(self):
+        response = self.get_json('/racks/123456',
+                expect_errors=True,
+                headers={"Accept":
+                    "application/json"}
+                )
+
+        self.assertEqual(response.status_int, 404)

--- a/tuskar/tests/test_v1.py
+++ b/tuskar/tests/test_v1.py
@@ -1,19 +1,126 @@
 """Base classes for API tests.
 """
 
-import os
-from oslo.config import cfg
-from tuskar.api import app
-from tuskar.tests import base
-from tuskar.api import acl
 from tuskar.tests import api
+from tuskar.db.sqlalchemy import api as dbapi
+from tuskar.api.controllers import v1
 
 
 class TestRacks(api.FunctionalTest):
 
+    test_rack = None
+    db = dbapi.get_backend()
 
-    def test_it_returns_valid_404(self):
-        response = self.get_json('/invalid_path',
+    def valid_rack_json(self, rack_json, test_rack=None):
+        rack = None
+
+        if test_rack is None:
+            rack = self.test_rack
+        else:
+            rack = test_rack
+
+        self.assertEqual(rack_json['id'], rack.id)
+        self.assertEqual(rack_json['name'], rack.name)
+        self.assertEqual(rack_json['slots'], rack.slots)
+        self.assertEqual(rack_json['subnet'], rack.subnet)
+        self.assertTrue(rack_json['nodes'])
+        print rack.id
+        print rack.nodes[0].id
+        self.assertEqual(rack_json['nodes'][0]['id'],
+                str(rack.nodes[0].id))
+        self.assertTrue(rack_json['capacities'])
+        self.assertEqual(rack_json['capacities'][0]['name'],
+                rack.capacities[0].name)
+        self.assertEqual(rack_json['capacities'][0]['value'],
+                rack.capacities[0].value)
+        self.assertTrue(rack_json['links'])
+        self.assertEqual(rack_json['links'][0]['rel'], 'self')
+        self.assertEqual(rack_json['links'][0]['href'],
+                'http://localhost/v1/racks/' + str(rack.id))
+
+    def setUp(self):
+        """Create 'test_rack'"""
+
+        super(TestRacks, self).setUp()
+        self.test_rack = self.db.create_rack(
+                v1.Rack(name='test-rack', slots=1,
+                    subnet='10.0.0.0/24',
+                    chassis=v1.Chassis(id='123'),
+                    capacities=[v1.Capacity(name='cpu', value='10')],
+                    nodes=[v1.Node(id='1')]
+                    ))
+        # FIXME: For some reason the 'self.test_rack' does not
+        #        lazy-load the 'nodes' and other attrs when
+        #        having more than 1 test method...
+        #
+        self.test_rack = self.db.get_rack(self.test_rack.id)
+
+    def tearDown(self):
+        self.db.delete_rack(self.test_rack.id)
+        super(TestRacks, self).tearDown()
+
+    def test_it_returns_single_rack(self):
+        response = self.get_json('/racks/' + str(self.test_rack.id),
+                expect_errors=True)
+
+        self.assertEqual(response.status_int, 200)
+        self.assertEqual(response.content_type, "application/json")
+        self.valid_rack_json(response.json)
+
+    def test_it_returns_rack_list(self):
+        response = self.get_json('/racks', expect_errors=True)
+        self.assertEqual(response.status_int, 200)
+        self.assertEqual(response.content_type, "application/json")
+
+        # The 'test_rack' is present in the racks listing:
+        rack_json = filter(lambda r: r['id'] == self.test_rack.id,
+                response.json)
+        self.assertEqual(len(rack_json), 1)
+
+        # And the Rack serialization is correct
+        self.valid_rack_json(rack_json[0])
+
+    def test_it_updates_rack(self):
+        json = {
+                'name': 'test-new-name'
+            }
+        response = self.put_json('/racks/' + str(self.test_rack.id),
+                params=json, status=200)
+        self.assertEqual(response.content_type, "application/json")
+        self.assertEqual(response.json['name'], json['name'])
+        updated_rack = self.db.get_rack(self.test_rack.id)
+        self.assertEqual(updated_rack.name, json['name'])
+
+    def test_it_creates_and_deletes_new_rack(self):
+        json = {
+                'name': 'test-rack-create',
+                'subnet': '127.0.0./24',
+                'slots': '10',
+                'capacities': [
+                    {'name': 'memory', 'value': '1024'}
+                ],
+                'nodes': [
+                    {'id': '1234567'},
+                    {'id': '7891011'}
+                ]
+               }
+        response = self.post_json('/racks', params=json, status=201)
+        self.assertEqual(response.content_type, "application/json")
+
+        self.assertTrue(response.json['id'])
+        self.assertEqual(response.json['name'], json['name'])
+        self.assertEqual(str(response.json['slots']), json['slots'])
+        self.assertEqual(response.json['subnet'], json['subnet'])
+        self.assertEqual(len(response.json['nodes']), 2)
+
+        # Make sure we delete the Rack we just created
+        self.db.delete_rack(response.json['id'])
+
+    # FIXME(mfojtik): This test will fail because of Pecan bug, see:
+    # https://github.com/tuskar/tuskar/issues/18
+    #
+    def test_it_returns_404_when_getting_unknown_rack(self):
+        response = self.get_json('/racks/unknown',
                 expect_errors=True,
                 headers={"Accept":
                     "application/json"}
@@ -21,8 +128,11 @@ class TestRacks(api.FunctionalTest):
 
         self.assertEqual(response.status_int, 404)
 
-    def test_it_returns_404_for_unknown_rack(self):
-        response = self.get_json('/racks/123456',
+    # FIXME(mfojtik): This test will fail because of Pecan bug, see:
+    # https://github.com/tuskar/tuskar/issues/18
+    #
+    def test_it_returns_404_when_deleting_unknown_rack(self):
+        response = self.delete_json('/racks/unknown',
                 expect_errors=True,
                 headers={"Accept":
                     "application/json"}


### PR DESCRIPTION
To run the tests:

```
(venv) ~/code/tuskar → testr run
```

The output should looks like this:

```
running=OS_STDOUT_CAPTURE=1 OS_STDERR_CAPTURE=1 OS_TEST_TIMEOUT=60 ${PYTHON:-python} -m subunit.run discover -t ./ ./  
/home/mfojtik/code/tuskar/.tox/venv/lib/python2.7/site-packages/pygments/plugin.py:39: UserWarning: Module argparse was already imported from /usr/lib64/python2.7/argparse.pyc, but /home/mfojtik/code/tuskar/.tox/venv/lib/python2.7/site-packages is being added to sys.path
  import pkg_resources
======================================================================
FAIL: tuskar.tests.test_v1.TestRacks.test_it_returns_404_for_unknown_rack
tags: worker-0
----------------------------------------------------------------------
pythonlogging:'': {{{
SELECT racks.created_at AS racks_created_at, racks.updated_at AS racks_updated_at, racks.id AS racks_id, racks.name AS racks_name, racks.slots AS racks_slots, racks.subnet AS racks_subnet, racks.chassis_id AS racks_chassis_id, racks.resource_class_id AS racks_resource_class_id 
FROM racks 
WHERE racks.id = ?
(u'123456',)
}}}

stderr: {{{
/home/mfojtik/code/tuskar/.tox/venv/lib/python2.7/site-packages/pecan/__init__.py:96: RuntimeWarning: `static_root` is only used when `debug` is True, ignoring
  RuntimeWarning
}}}

stdout: {{{GET: /v1/racks/123456 {}}}}

Traceback (most recent call last):
  File "tuskar/tests/test_v1.py", line 28, in test_it_returns_404_for_unknown_rack
    "application/json"}
  File "tuskar/tests/api.py", line 122, in get_json
    expect_errors=expect_errors)
# ....
  File "/home/mfojtik/code/tuskar/.tox/venv/lib/python2.7/site-packages/wsme/rest/json.py", line 51, in tojson
    attr_value = getattr(value, attr.key)
AttributeError: 'NoneType' object has no attribute 'capacities'
======================================================================
FAIL: process-returncode
tags: worker-0
----------------------------------------------------------------------
Binary content:
  traceback (test/plain; charset="utf8")
Ran 7 tests in 0.185s (-0.001s)
FAILED (id=53, failures=2)

```

Now there are two quirks I dunno how to solve now:
1. Get rid of the 'UserWarning: Module argparse was already imported' message.
2. Figure how throw the bloody 404 error out from the pecan controller action (as you can see above, the fix I mentioned in https://github.com/tuskar/tuskar/issues/18#issuecomment-20747279 no longer works :-(
