### PR TITLE
Fixed handling of 404 errors for Rack GET and DELETE

### DIFF
--- a/tuskar/db/sqlalchemy/api.py
+++ b/tuskar/db/sqlalchemy/api.py
@@ -78,7 +78,7 @@ class Connection(api.Connection):
                     subqueryload('nodes')
                     ).filter_by(id=rack_id).one()
         except NoResultFound:
-            raise exception.RackNotFound(rack=rack_id)
+            result = None
 
         return result
 
@@ -249,6 +249,8 @@ class Connection(api.Connection):
     def delete_rack(self, rack_id):
         session = get_session()
         rack = self.get_rack(rack_id)
+        if not rack:
+            return False
         session.begin()
         try:
             session.delete(rack)
@@ -268,6 +270,7 @@ class Connection(api.Connection):
             session.query(models.ResourceClass
                           ).filter_by(id=resource_class_id).delete()
             session.commit()
+            return True
         except Exception:
             session.rollback()
             raise


### PR DESCRIPTION
This should resolved following issues:

https://github.com/tuskar/tuskar/issues/18
https://github.com/tuskar/tuskar/issues/22
https://github.com/tuskar/tuskar/issues/21

Note this is just an 'attempt' to fix this problem, by workarounding
the wsmext parsing and using just plain Pecan @expose().

The validation of WSME complex type input is not done when
using thing method, so this way might not be the best way for
handling PUT and POST.
