### PR TITLE
Add a class for custom Json renderer.

### DIFF
--- a/tuskar/api/app.py
+++ b/tuskar/api/app.py
@@ -22,6 +22,7 @@ import pecan
 from tuskar.api import acl
 from tuskar.api import config
 from tuskar.api import hooks
+from tuskar.api import renderers
 
 auth_opts = [
     cfg.StrOpt('auth_strategy',
@@ -56,6 +57,7 @@ def setup_app(pecan_config=None, extra_hooks=None):
 # TODO(deva): add middleware.ParsableErrorMiddleware from Ceilometer
     app = pecan.make_app(
         pecan_config.app.root,
+        custom_renderers=dict(wsmejson=renderers.JSonRenderer),
         static_root=pecan_config.app.static_root,
         template_path=pecan_config.app.template_path,
         debug=CONF.debug,

--- a/tuskar/api/renderers.py
+++ b/tuskar/api/renderers.py
@@ -1,0 +1,45 @@
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+# -*- encoding: utf-8 -*-
+# Copyright 2013 Red Hat, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import json
+
+import pecan
+import wsme
+from wsme import api
+
+
+class JSonRenderer(object):
+    """Custom json renderer.
+
+    Renders to json and handles responses for various HTTP status codes.
+    """
+    def __init__(self, path, extra_vars):
+        pass
+
+    def render(self, template_path, namespace):
+        result = namespace['result']
+        if isinstance(namespace['result'], api.Response):
+            pecan.response.status_code = result.status_code
+            val = json.dumps({'faultstring': result.obj.faultstring,
+                               'faultcode': result.obj.faultcode})
+            return val
+
+        if 'faultcode' in namespace:
+            return wsme.rest.json.encode_error(None, namespace)
+        return wsme.rest.json.encode_result(
+            namespace['result'],
+            namespace['datatype']
+        )


### PR DESCRIPTION
The custom renderer adds the ability to handle unexpected responses by checking
the value of the return value from the controller method.  This allows for
setting different http status codes (such as 404) instead of just the 400 or
500 that wsme allows.
