### PR TITLE
Initial HEAT template generation work

### DIFF
--- a/tuskar/api/config.py
+++ b/tuskar/api/config.py
@@ -9,7 +9,7 @@ app = {
     'root': 'tuskar.api.controllers.root.RootController',
     'modules': ['tuskar.api'],
     'static_root': '%(confdir)s/public',
-    'template_path': '%(confdir)s/tuskar/api/templates',
+    'template_path': '%(confdir)s/templates',
     'debug': False,
     'enable_acl': False,
 }

--- a/tuskar/api/controllers/v1.py
+++ b/tuskar/api/controllers/v1.py
@@ -390,6 +390,7 @@ class ResourceClassesController(rest.RestController):
     def delete(self, resource_class_id):
         """Remove the Resource Class."""
         pecan.request.dbapi.delete_resource_class(resource_class_id)
+
     """
     @wsme_pecan.wsexpose(None, wtypes.text, wtypes.text, status_code=204)
     def flavors(self, foo_id, resource_class_id):
@@ -407,6 +408,20 @@ class ResourceClassesController(rest.RestController):
         else:
             return "ERROR"
     """
+
+
+class DataCentreController(object):
+    """Controller for provisioning the Tuskar data centre description as an
+    overcloud on Triple O"""
+
+    # TODO (mtaylor) Currently this returns an OverCloud HEAT template.  It
+    # should push the overcloud template to HEAT.
+    @pecan.expose(template='overcloud.yaml')
+    def index(self):
+        rcs = pecan.request.dbapi.get_heat_data()
+        return dict(resource_classes=rcs)
+
+
 class Controller(object):
     """Version 1 API controller root."""
 
@@ -414,6 +429,7 @@ class Controller(object):
 
     resource_classes = ResourceClassesController()
 
+    data_centres = DataCentreController()
 
     @pecan.expose('json')
     def index(self):

--- a/tuskar/api/templates/compute.yaml
+++ b/tuskar/api/templates/compute.yaml
@@ -1,0 +1,86 @@
+<%def name="render(x)">\
+  NovaCompute${x}:
+    Metadata:
+      OpenStack::ImageBuilder::Elements:
+      - nova-compute
+      admin-password: unset
+      glance:
+        host:
+          Fn::GetAtt:
+          - notcompute
+          - PrivateIp
+      heat:
+        access_key_id:
+          Ref: Key
+        refresh:
+        - resource: NovaCompute
+        secret_key:
+          Fn::GetAtt:
+          - Key
+          - SecretAccessKey
+        stack:
+          name:
+            Ref: AWS::StackName
+          region:
+            Ref: AWS::Region
+      interfaces:
+        control:
+          Ref: NovaInterfaces
+      keystone:
+        host:
+          Fn::GetAtt:
+          - notcompute
+          - PrivateIp
+      neutron:
+        host:
+          Fn::GetAtt:
+          - notcompute
+          - PrivateIp
+        ovs:
+          bridge_mappings: ''
+          enable_tunneling: 'True'
+          local_ip: 0.0.0.0
+          network_vlan_ranges: ''
+          tenant_network_type: gre
+        ovs_db:
+          Fn::Join:
+          - ''
+          - - mysql://neutron:unset@
+            - Fn::GetAtt:
+              - notcompute
+              - PrivateIp
+            - /neutron
+      nova:
+        compute_driver:
+          Ref: NovaComputeDriver
+        db:
+          Fn::Join:
+          - ''
+          - - mysql://nova:unset@
+            - Fn::GetAtt:
+              - notcompute
+              - PrivateIp
+            - /nova
+        host:
+          Fn::GetAtt:
+          - notcompute
+          - PrivateIp
+      rabbit:
+        host:
+          Fn::GetAtt:
+          - notcompute
+          - PrivateIp
+        password: guest
+      service-password: unset
+      swift:
+        store_key: ''
+        store_user: ''
+    Properties:
+      ImageId:
+        Ref: NovaImage
+      InstanceType:
+        Ref: InstanceType
+      KeyName:
+        Ref: KeyName
+    Type: AWS::EC2::Instance
+</%def>\

--- a/tuskar/api/templates/not_compute.yaml
+++ b/tuskar/api/templates/not_compute.yaml
@@ -1,0 +1,80 @@
+<%def name="render(x=0)">\
+  notcompute:
+    Metadata:
+      OpenStack::Heat::Stack: {}
+      Openstack::ImageBuilder::Elements:
+      - boot-stack
+      - heat-cfntools
+      - heat-localip
+      - neutron-network-node
+      admin-password: unset
+      admin-token: unset
+      cinder:
+        db: mysql://cinder:unset@localhost/cinder
+        volume_size_mb: '5000'
+      controller-address: 192.0.2.5
+      db-password: unset
+      glance:
+        db: mysql://glance:unset@localhost/glance
+        host: 192.0.2.5
+      heat:
+        access_key_id:
+          Ref: Key
+        admin_password: unset
+        admin_tenant_name: service
+        admin_user: heat
+        auth_encryption_key: unset___________
+        db: mysql://heat:unset@localhost/heat
+        heat_watch_server_url: http://192.0.2.5:8003
+        metadata_server_url: http://192.0.2.5:8000
+        refresh:
+        - resource: notcompute
+        secret_key:
+          Fn::GetAtt:
+          - Key
+          - SecretAccessKey
+        stack:
+          name:
+            Ref: AWS::StackName
+          region:
+            Ref: AWS::Region
+        waitcondition_server_url: http://192.0.2.5:8000/v1/waitcondition
+      interfaces:
+        control: eth2
+      keystone:
+        db: mysql://keystone:unset@localhost/keystone
+        host: 192.0.2.5
+      neutron:
+        floatingip_end: 192.0.2.64
+        floatingip_range: 192.0.2.0/24
+        floatingip_start: 192.0.2.45
+        host: 192.0.2.5
+        metadata_proxy_shared_secret: unset
+        ovs:
+          enable_tunneling: 'True'
+          fixed_range:
+            end: 10.255.255.254
+            start: 10.0.0.2
+          local_ip: 192.0.2.5
+          ovs_range: 10.0.0.0/8
+          public_interface: eth0
+          tenant_network_type: gre
+        ovs_db: mysql://neutron:unset@localhost/ovs_neutron?charset=utf8
+      nova:
+        compute_driver: libvirt.LibvirtDriver
+        db: mysql://nova:unset@localhost/nova
+        host: 192.0.2.5
+        metadata-proxy: true
+      rabbit:
+        host: 192.0.2.5
+        password: guest
+      service-password: unset
+    Properties:
+      ImageId:
+        Ref: notcomputeImage
+      InstanceType:
+        Ref: InstanceType
+      KeyName:
+        Ref: KeyName
+    Type: AWS::EC2::Instance
+</%def>\

--- a/tuskar/api/templates/overcloud.yaml
+++ b/tuskar/api/templates/overcloud.yaml
@@ -1,0 +1,53 @@
+<%namespace name="not_compute" file="not_compute.yaml"/>\
+<%namespace name="compute" file="compute.yaml"/>\
+<% # Mapping between resource class service type and a HEAT template
+   # TODO (mtaylor) Move this into Config file or add to model via API call. 
+   templates = {"compute": compute, "not_compute": not_compute} %>\
+Description: Nova API,Keystone,Heat Engine and API,Glance,Neutron,Dedicated MySQL
+  server,Dedicated RabbitMQ Server,Group of Nova Computes
+HeatTemplateFormatVersion: '2012-12-12'
+Parameters:
+  InstanceType:
+    Default: baremetal
+    Description: Flavor to request when deploying.
+    Type: String
+  KeyName:
+    Default: default
+    Description: Name of an existing EC2 KeyPair to enable SSH access to the instances
+    Type: String
+  NovaComputeDriver:
+    Default: libvirt.LibvirtDriver
+    Type: String
+  NovaImage:
+    Default: overcloud-compute
+    Type: String
+  NovaInterfaces:
+    Default: eth0
+    Type: String
+  PowerUserName:
+    Default: stack
+    Description: What username to ssh to the virtual power host with.
+    Type: String
+  notcomputeImage:
+    Type: String
+Resources:
+  AccessPolicy:
+    Properties:
+      AllowedResources:
+      - notcompute
+    Type: OS::Heat::AccessPolicy
+  Key:
+    Properties:
+      UserName:
+        Ref: User
+    Type: AWS::IAM::AccessKey
+  User:
+    Properties:
+      Policies:
+      - Ref: AccessPolicy
+    Type: AWS::IAM::User
+<% for rc in resource_classes:
+       for r in rc.racks:
+           for n in r.nodes:
+               templates[rc.service_type].render(n.id)
+%>

--- a/tuskar/db/sqlalchemy/api.py
+++ b/tuskar/db/sqlalchemy/api.py
@@ -21,7 +21,7 @@ from oslo.config import cfg
 
 # TODO(deva): import MultipleResultsFound and handle it appropriately
 from sqlalchemy.orm.exc import NoResultFound
-from sqlalchemy.orm import subqueryload
+from sqlalchemy.orm import subqueryload, joinedload
 
 from tuskar.common import exception
 from tuskar.db import api
@@ -62,6 +62,12 @@ class Connection(api.Connection):
 
     def __init__(self):
         pass
+
+    def get_heat_data(self):
+        session = get_session()
+        return session.query(models.ResourceClass).options(
+                    joinedload(models.ResourceClass.racks),
+                ).all()
 
     def get_racks(self, columns):
         session = get_session()


### PR DESCRIPTION
To test, clear DB and run commands below, the result should be a HEAT template with 6 compute nodes and 1 non compute node.

N.B. The HEAT template does not define availability zones for the nodes, therefore the nodes could be deployed onto any rack.  To be fixed in subsequent patch.
# Create Racks

Creates 3 Racks.

2 Racks are assigned to compute resource class and contain 3 bare metal nodes each.
1 Rack is designated to non compute resource class and contains 1 bare metal node only.

```
curl -vX POST -H 'Content-Type: application/json' -H 'Accept: application/json' -v -d  '
{
  "subnet": "192.168.1.0/255",
  "name": "compute_1",
  "capacities": [{
    "name": "total_cpu",
    "value": "64"
  }, {
    "name": "total_memory",
    "value": "1024"
  }],
  "nodes": [
  {
    "id": "nova_bare_metal_1"
  },
  {
    "id": "nova_bare_metal_2"
  }, 
  {
    "id": "nova_bare_metal_3"
  }
  ],
  "slots": 3
}
' http://0.0.0.0:6385/v1/racks

curl -vX POST -H 'Content-Type: application/json' -H 'Accept: application/json' -v -d  '
{
  "subnet": "192.168.2.0/255",
  "name": "compute_2",
  "capacities": [{
    "name": "total_cpu",
    "value": "64"
  }, {
    "name": "total_memory",
    "value": "1024"
  }],
  "nodes": [
  {
    "id": "nova_bare_metal_4"
  },
  {
    "id": "nova_bare_metal_5"
  }, 
  {
    "id": "nova_bare_metal_6"
  }
  ],
  "slots": 3
}
' http://0.0.0.0:6385/v1/racks

curl -vX POST -H 'Content-Type: application/json' -H 'Accept: application/json' -v -d  '
{
  "subnet": "192.168.2.0/255",
  "name": "compute_2",
  "capacities": [{
    "name": "total_cpu",
    "value": "64"
  }, {
    "name": "total_memory",
    "value": "1024"
  }],
  "nodes": [
  {
    "id": "nova_bare_metal_7"
  }],
  "slots": 3
}
' http://0.0.0.0:6385/v1/racks
```
# Create Resource Classes

Creates 2 resource classes

Compute: This contains 2 racks, totally 6 nodes
Not Compuite: Contains 1 Rack, 1 Node

```
curl -iX POST -H 'Content-Type: application/json' -H 'Accept: application/json' -d '
    {
          "name": "compute-rc", 
          "service_type":"compute",
          "racks": [
              { 
                "id":1,
                "links":[{"href":"http://0.0.0.0:6385/v1/racks/1","rel":"self"}]
              },
              { 
                "id":2,
                "links":[{"href":"http://0.0.0.0:6385/v1/racks/2","rel":"self"}]
              }
           ],
           "flavors": [
                { "name" : "x-large",
                  "capacities" : [
                     {   "name": "cpu", 
                         "value" : "4",
                          "unit" : "count" }, 
                     {   "name": "memory",
                         "value" : "8192",
                         "unit" : "MiB" },
                     {   "name": "storage", 
                         "value" : "1024",
                         "unit" : "GiB" }
                  ]
                }
           ]
      }
' http://0.0.0.0:6385/v1/resource_classes

curl -iX POST -H 'Content-Type: application/json' -H 'Accept: application/json' -d '
    {
          "name": "non-compute-rc", 
          "service_type":"not_compute",
          "racks": [
              { 
                "id":3,
                "links":[{"href":"http://0.0.0.0:6385/v1/racks/3","rel":"self"}]
              }
           ]
      }
' http://0.0.0.0:6385/v1/resource_classes
```
# GET HEAT Template

Generates HEAT template based on Tuskar description.

```
curl http://0.0.0.0:6385/v1/data_centres
```
