### PR TITLE
Allow setting and getting of resource class on Rack

### DIFF
--- a/tuskar/api/controllers/v1.py
+++ b/tuskar/api/controllers/v1.py
@@ -96,6 +96,13 @@ class Error(Base):
     faultstring = wtypes.text
 
 
+class Relation(Base):
+    """A representation of a 1 to 1 or 1 to many relation in the database"""
+
+    id = int
+    links = [Link]
+
+
 class Chassis(Base):
     """A chassis representation."""
 
@@ -129,6 +136,7 @@ class Rack(Base):
     capacities = [Capacity]
     nodes = [Node]
     links = [Link]
+    resource_class = Relation
 
     @classmethod
     def convert_with_links(self, rack, links):
@@ -138,6 +146,13 @@ class Rack(Base):
                               links=[_ironic_link('chassis', rack.chassis_id)])
         else:
             chassis = Chassis()
+
+        if rack.resource_class_id:
+            import IPython
+            IPython.embed()
+            l = [_make_link('self', pecan.request.host_url, 'resource_classes',
+                                rack.resource_class_id)]
+            self.resource_class = Relation(id=rack.resource_class_id, links=l)
 
         capacities = [Capacity(name=c.name, value=c.value)
                       for c in rack.capacities]

--- a/tuskar/db/sqlalchemy/api.py
+++ b/tuskar/db/sqlalchemy/api.py
@@ -209,6 +209,11 @@ class Connection(api.Connection):
             if new_rack.chassis:
                 rack.chassis_id = new_rack.chassis.id
 
+            if not isinstance(new_rack.resource_class, wtypes.UnsetType):
+                rc = self.get_resource_class(new_rack.resource_class.get_id())
+                session.add(rc)
+                rack.resource_class = rc
+
             session.add(rack)
 
             # TODO(mfojtik): Since the 'PUT' does not behave like PATCH, we
@@ -253,6 +258,11 @@ class Connection(api.Connection):
             if new_rack.chassis:
                 rack.chassis_id = new_rack.chassis.id
 
+            if not isinstance(new_rack.resource_class, wtypes.UnsetType):
+                rc = self.get_resource_class(new_rack.resource_class.get_id())
+                session.add(rc)
+                rack.resource_class = rc
+
             session.add(rack)
 
             if new_rack.capacities:
@@ -268,6 +278,7 @@ class Connection(api.Connection):
                     session.add(node)
                     rack.nodes.append(node)
                     session.add(rack)
+
 
             session.commit()
             session.refresh(rack)


### PR DESCRIPTION
Fixes: #29
### Create with Resource Class

``` json
curl -vX POST -H 'Content-Type: application/json' -H 'Accept: application/json' -v -d  '
{
  "subnet": "192.168.1.0/255",
  "name": "my_rack",
  "capacities": [{
    "name": "total_cpu",
    "value": "64"
  }, {
    "name": "total_memory",
    "value": "1024"
  }],
  "nodes": [{
    "id": "123"
  }, {
    "id": "345"
  }],
  "slots": 1,
  "resource_class":{
       "id":1,
       "links":[
          {
             "href":"http://0.0.0.0:6385/v1/resource_clases/1",
             "rel":"self"
          }
       ]
    }
}
' http://0.0.0.0:6385/v1/racks
```
