### PR TITLE
Invalid sample data

### DIFF
--- a/tools/sample_data.py
+++ b/tools/sample_data.py
@@ -125,8 +125,8 @@ def set_nodes_on_rack(conn, base_url, rack_url, nodes):
                         body=dict(nodes=nodes))
 
 
-def create_flavor(conn, base_url, flavor):
-    return json_request(conn, base_url, '/flavors', 'POST', body=flavor)
+def create_flavor(conn, base_url, resource_class_url, flavor):
+    return json_request(conn, base_url + resource_class_url, '/flavors', 'PUT', body=flavor)
 
 
 def get_location(base_url, resp):
@@ -190,4 +190,4 @@ if __name__ == '__main__':
              ]),
     ]
     for flavor in flavors:
-        create_flavor(conn, base_url, flavor)
+        create_flavor(conn, base_url, m1_url, flavor)


### PR DESCRIPTION
When running "python tools/sample_data.py", I get this error:
curl -i -X POST -H 'Content-Type: application/json' -H 'Accept: application/json' -d '{"capacities": [{"unit": "count", "value": "1", "name": "cpu"}, {"unit": "GB", "value": "1.7", "name": "memory"}, {"unit": "GB", "value": "160", "name": "storage"}], "name": "m1.small"}' http://localhost:6385/v1/flavors
Request returned failure/redirect status.
Traceback (most recent call last):
  File "tools/sample_data.py", line 193, in <module>
    create_flavor(conn, base_url, flavor)
  File "tools/sample_data.py", line 129, in create_flavor
    return json_request(conn, base_url, '/flavors', 'POST', body=flavor)
  File "tools/sample_data.py", line 96, in json_request
    resp, body = http_request(conn, base_url, url, method, **kwargs)
  File "tools/sample_data.py", line 79, in http_request
    raise RuntimeError('Status code %d returned' % resp.status)
RuntimeError: Status code 404 returned

It might be that flavors creation in sample_data is obsolete (flavors are not top-level resource anymore).
