### PR TITLE
Improvements of Heat stack update

### DIFF
--- a/tuskar/api/controllers/v1.py
+++ b/tuskar/api/controllers/v1.py
@@ -322,13 +322,12 @@ class FlavorsController(rest.RestController):
         """Create a new Flavor for a ResourceClass."""
         try:
             flavor = pecan.request.dbapi.create_resource_class_flavor(
-                                            resource_class_id,flavor)
+                                            resource_class_id, flavor)
         except Exception as e:
             LOG.exception(e)
             raise wsme.exc.ClientSideError(_("Invalid data"))
         pecan.response.status_code = 201
         return Flavor.add_capacities(resource_class_id, flavor)
-
 
     #Do we need this, i.e. GET /api/resource_classes/1/flavors
     #i.e. return just the flavors for a given resource_class?
@@ -450,18 +449,28 @@ class ResourceClassesController(rest.RestController):
     """
 
 
-class DataCenterController(object):
+class DataCenterController(rest.RestController):
     """Controller for provisioning the Tuskar data centre description as an
     overcloud on Triple O"""
 
+    #@pecan.expose('json')
+    #def index(self):
+    #    return {'message': 'hello'}
+
     @pecan.expose('json')
-    def index(self):
+    def post(self, data):
         rcs = pecan.request.dbapi.get_heat_data()
+        # TODO: Currently all Heat parameters are hardcoded in
+        #       template.
+        params = {}
         template_body = render('overcloud.yaml', dict(resource_classes=rcs))
         if heat_client().validate_template(template_body):
-            # TODO(mfojtik): Use ResourceClass name as Heat Stack name
-            # TODO(mfojtik): How we will pass parameters to heat? (params).
-            heat_client().register_template(rcs[0].name, template_body, params)
+            heat_client().update_stack(template_body, params)
+            pecan.response.status_code = 202  # Accepted
+            return heat_client().get_stack()
+        else:
+            raise wsme.exc.ClientSideError(_("The overcloud Heat template" +
+                "could not be validated"))
 
 
 class Controller(object):

--- a/tuskar/api/controllers/v1.py
+++ b/tuskar/api/controllers/v1.py
@@ -467,6 +467,10 @@ class DataCenterController(rest.RestController):
         if heat_client().validate_template(template_body):
             heat_client().update_stack(template_body, params)
             pecan.response.status_code = 202  # Accepted
+            # Update the state of each Rack to 'provisioned'
+            for rc in rcs:
+                [pecan.request.dbapi.update_rack_state(r, 'provisioned') for r
+                        in rc.racks]
             return heat_client().get_stack()
         else:
             raise wsme.exc.ClientSideError(_("The overcloud Heat template" +

--- a/tuskar/db/sqlalchemy/api.py
+++ b/tuskar/db/sqlalchemy/api.py
@@ -238,6 +238,17 @@ class Connection(api.Connection):
             session.rollback()
             raise
 
+    def update_rack_state(self, rack, new_state):
+        session = get_session()
+        session.begin()
+        try:
+            rack.state = new_state
+            session.add(rack)
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+
     def update_rack(self, rack_id, new_rack):
         session = get_session()
         session.begin()


### PR DESCRIPTION
Hi,

This patch follows the previously merged patch for the initial import. This patch adds:
- Support for the 'overcloud' Heat stack, that we assume is already created.
- Support for updating this Heat stack:

```
curl -XPOST -H 'Content-Type:application/json' -H 'Accept: application/json' http://0.0.0.0.0:6385/v1/data_centers/
```

Issuing this command, the overcloud Heat template will be updated and the Racks will be registered from all ResourceClasses
- The 'Rack' state will change to 'provisioned' once the Rack is properly registered in Heat 
