### PR TITLE
Changes format and indents for pep8

### DIFF
--- a/tuskar/compute/nova.py
+++ b/tuskar/compute/nova.py
@@ -52,20 +52,20 @@ nova_opts = [
                default='$my_ip',
                help='default nova hostname or ip'),
     cfg.IntOpt('nova_port',
-               default=8774, #FIXME IS THAT RIGHT?
+               default=8774,  # FIXME IS THAT RIGHT?
                help='default nova port'),
     cfg.StrOpt('nova_protocol',
-                default='http',
-                help='Default protocol to use when connecting to glance. '
-                     'Set to https for SSL.'),
+               default='http',
+               help='Default protocol to use when connecting to glance. '
+               'Set to https for SSL.'),
     cfg.BoolOpt('nova_api_insecure',
                 default=False,
                 help='Allow to perform insecure SSL (https) requests to '
-                     'nova'),
+                'nova'),
     cfg.IntOpt('nova_num_retries',
                default=0,
                help='Number retries when calling novaclient'),
-    ]
+]
 
 LOG = logging.getLogger(__name__)
 CONF = cfg.CONF
@@ -79,18 +79,22 @@ def generate_nova_url():
     return "%s://%s:%d" % (CONF.nova_protocol, CONF.nova_host,
                            CONF.nova_port)
 
+
 def _create_nova_client(context, host, port, use_ssl, version=1):
     """Instantiate a new novaclient.Client object."""
     if use_ssl:
         scheme = 'https'
     else:
         scheme = 'http'
+
     params = {}
     params['insecure'] = CONF.nova_api_insecure
     if CONF.auth_strategy == 'keystone':
         params['token'] = context.auth_token
+
     endpoint = '%s://%s:%s' % (scheme, host, port)
     return novaclient.Client(str(version), endpoint, **params)
+
 
 class NovaClientWrapper(object):
     """Nova client wrapper class that implements retries."""
@@ -103,6 +107,7 @@ class NovaClientWrapper(object):
                                                      use_ssl, version)
         else:
             self.client = None
+
         self.api_servers = None
 
     def _create_static_client(self, context, host, port, use_ssl, version):
@@ -112,26 +117,28 @@ class NovaClientWrapper(object):
         self.use_ssl = use_ssl
         self.version = version
         return _create_nova_client(context,
-                                     self.host, self.port,
-                                     self.use_ssl, self.version)
+                                   self.host, self.port,
+                                   self.use_ssl, self.version)
 
     def _create_onetime_client(self, context, version):
         """Create a client that will be used for one call."""
         if self.api_servers is None:
             self.api_servers = get_api_servers()
+
         self.host, self.port, self.use_ssl = self.api_servers.next()
         return _create_nova_client(context,
-                                     self.host, self.port,
-                                     self.use_ssl, version)
+                                   self.host, self.port,
+                                   self.use_ssl, version)
 
     def call(self, context, version, method, *args, **kwargs):
-        """
-        Call a nova client method.  If we get a connection error,
+        """Call a nova client method.
+
+        If we get a connection error,
         retry the request according to CONF.glance_num_retries.
         """
         retry_excs = (novaclient.exc.ServiceUnavailable,
-                novaclient.exc.InvalidEndpoint,
-                novaclient.exc.CommunicationError)
+                      novaclient.exc.InvalidEndpoint,
+                      novaclient.exc.CommunicationError)
         num_attempts = 1 + CONF.nova_num_retries
 
         for attempt in xrange(1, num_attempts + 1):
@@ -144,12 +151,12 @@ class NovaClientWrapper(object):
                 port = self.port
                 extra = "retrying"
                 error_msg = _("Error contacting nova server "
-                        "'%(host)s:%(port)s' for '%(method)s', %(extra)s.")
+                              "'%(host)s:%(port)s' for '%(method)s', %(extra)s.")
                 if attempt == num_attempts:
                     extra = 'done trying'
                     LOG.exception(error_msg, locals())
                     raise exception.novaConnectionFailed(
-                            host=host, port=port, reason=str(e))
+                        host=host, port=port, reason=str(e))
                 LOG.exception(error_msg, locals())
                 time.sleep(1)
 
@@ -170,7 +177,7 @@ class NovaFlavorService(object):
 
         _flavors = []
         for flavor in flavors:
-                _flavors.append(self._translate_from_nova_flavor(flavor))
+            _flavors.append(self._translate_from_nova_flavor(flavor))
 
         return _flavors
 
@@ -195,6 +202,7 @@ class NovaFlavorService(object):
             nova_flavor = self._client.call(context, 1, 'get', flavor_id)
         except Exception:
             _reraise_translated_exception()
+
         flavor = self._translate_from_nova_flavor(nova_flavor)
         return flavor
 
@@ -221,11 +229,13 @@ class NovaFlavorService(object):
         flavor = _extract_attributes(nova_flavor)
         return flavor
 
+
 def _extract_attributes(flavor):
     FLAVOR_ATTRIBUTES = ['id', 'name', 'ram', 'disk', 'vcpus']
     output = {}
     for attr in FLAVOR_ATTRIBUTES:
         output[attr] = getattr(flavor, attr, None)
+
     return output
 
 
@@ -235,15 +245,17 @@ def _reraise_translated_exception():
     new_exc = _translate_plain_exception(exc_value)
     raise new_exc, None, exc_trace
 
+
 def _translate_plain_exception(exc_value):
     if isinstance(exc_value, (novaclient.exc.Forbidden,
-                    novaclient.exc.Unauthorized)):
+                              novaclient.exc.Unauthorized)):
         return exception.NotAuthorized(exc_value)
     if isinstance(exc_value, novaclient.exc.NotFound):
         return exception.NotFound(exc_value)
     if isinstance(exc_value, novaclient.exc.BadRequest):
         return exception.Invalid(exc_value)
     return exc_value
+
 
 def get_default_flavor_service():
     return NovaFlavorService()

--- a/tuskar/db/sqlalchemy/models.py
+++ b/tuskar/db/sqlalchemy/models.py
@@ -103,7 +103,7 @@ class RackCapacities(Base):
     id = Column(Integer, primary_key=True)
     rack_id = Column(Integer, ForeignKey('racks.id'), primary_key=True)
     capacity_id = Column(Integer, ForeignKey('capacities.id'),
-            primary_key=True)
+                         primary_key=True)
 
 
 class FlavorCapacities(Base):
@@ -113,7 +113,7 @@ class FlavorCapacities(Base):
     #FIXME - I want flavor.id to be UUID String
     flavor_id = Column(Integer, ForeignKey('flavors.id'), primary_key=True)
     capacity_id = Column(Integer, ForeignKey('capacities.id'),
-            primary_key=True)
+                         primary_key=True)
 
 
 class Node(Base):
@@ -139,10 +139,12 @@ class Rack(Base):
     resource_class_id = Column(Integer, ForeignKey('resource_classes.id',
                                                    onupdate="cascade"))
     capacities = relationship("Capacity",
-            secondary=Base.metadata.tables['rack_capacities'],
-            cascade="all, delete",
-            lazy='joined')
+                              secondary=
+                              Base.metadata.tables['rack_capacities'],
+                              cascade="all, delete",
+                              lazy='joined')
     nodes = relationship("Node", cascade="all, delete")
+
 
 class Flavor(Base):
     """Represents a Flavor Class."""
@@ -155,9 +157,11 @@ class Flavor(Base):
                                                    onupdate="cascade"))
     max_vms = Column(Integer)
     capacities = relationship("Capacity",
-            secondary=Base.metadata.tables['flavor_capacities'],
-            cascade="all, delete",
-            lazy='joined')
+                              secondary=
+                              Base.metadata.tables['flavor_capacities'],
+                              cascade="all, delete",
+                              lazy='joined')
+
 
 class ResourceClass(Base):
     """Represents a Resource Class."""
@@ -172,8 +176,7 @@ class ResourceClass(Base):
                          cascade="all",
                          passive_updates=False)
     flavors = relationship("Flavor",
-                         backref="resource_class",
-                         lazy='joined',
-                         cascade="all",
-                         passive_updates=False)
-
+                           backref="resource_class",
+                           lazy='joined',
+                           cascade="all",
+                           passive_updates=False)

--- a/tuskar/heat/client.py
+++ b/tuskar/heat/client.py
@@ -27,31 +27,31 @@ from tuskar.openstack.common import log as logging
 
 heat_opts = [
 
-        cfg.StrOpt('heat_username',
-            default='heat',
-            help='Heat API username'),
+    cfg.StrOpt('heat_username',
+               default='heat',
+               help='Heat API username'),
 
-        cfg.StrOpt('heat_password',
-            default='heat',
-            help='Heat API password'),
+    cfg.StrOpt('heat_password',
+               default='heat',
+               help='Heat API password'),
 
-        cfg.StrOpt('heat_auth_url',
-            default='http://10.34.32.181:35357/v2.0/',
-            help='OpenStack Authentication URL (OS_AUTH_URL)'),
+    cfg.StrOpt('heat_auth_url',
+               default='http://10.34.32.181:35357/v2.0/',
+               help='OpenStack Authentication URL (OS_AUTH_URL)'),
 
-        cfg.StrOpt('heat_tenant_name',
-            default='admin',
-            help='Heat API tenant_id'),
+    cfg.StrOpt('heat_tenant_name',
+               default='admin',
+               help='Heat API tenant_id'),
 
-        cfg.StrOpt('heat_stack_name',
-            default='overcloud',
-            help='Default Heat overcloud stack name'
-            ),
+    cfg.StrOpt('heat_stack_name',
+               default='overcloud',
+               help='Default Heat overcloud stack name'
+               ),
 
-        cfg.BoolOpt('heat_auth_url_insecure',
-            default=True,
-            help='Use HTTPs to speak with Heat'
-            )
+    cfg.BoolOpt('heat_auth_url_insecure',
+                default=True,
+                help='Use HTTPs to speak with Heat'
+                )
 ]
 
 CONF = cfg.CONF
@@ -92,7 +92,7 @@ class HeatClient(object):
         endpoint = _get_endpoint(_ksclient, **kwargs)
 
         self.connection = heatclient(endpoint=endpoint,
-                token=_ksclient.auth_token)
+                                     token=_ksclient.auth_token)
 
     def validate_template(self, template_body):
         """Validate given Heat template"""
@@ -115,7 +115,8 @@ class HeatClient(object):
         """Update the Heat overcloud stack"""
         try:
             self.connection.stacks.update(stack_id=CONF.heat_stack_name,
-                template=template_body, parameters=params)
+                                          template=template_body,
+                                          parameters=params)
             return True
         except Exception as e:
             LOG.exception(e)

--- a/tuskar/tests/api.py
+++ b/tuskar/tests/api.py
@@ -18,14 +18,15 @@
 """Base classes for API tests.
 """
 
-import urllib
-from oslo.config import cfg
+# import urllib
 
+
+from oslo.config import cfg
 import pecan
 import pecan.testing
 
-from tuskar.openstack.common import jsonutils
 from tuskar.api import acl
+# from tuskar.openstack.common import jsonutils
 from tuskar.tests import base
 
 
@@ -74,7 +75,7 @@ class FunctionalTest(base.TestCase):
                               status=status, method="put")
 
     def delete_json(self, path, expect_errors=False, headers=None,
-                 extra_environ=None, status=None):
+                    extra_environ=None, status=None):
         return self.post_json(path=path, params={},
                               expect_errors=expect_errors,
                               headers=headers, extra_environ=extra_environ,

--- a/tuskar/tests/test_v1.py
+++ b/tuskar/tests/test_v1.py
@@ -1,9 +1,9 @@
 """Base classes for API tests.
 """
 
-from tuskar.tests import api
-from tuskar.db.sqlalchemy import api as dbapi
 from tuskar.api.controllers import v1
+from tuskar.db.sqlalchemy import api as dbapi
+from tuskar.tests import api
 
 
 class TestRacks(api.FunctionalTest):
@@ -27,19 +27,19 @@ class TestRacks(api.FunctionalTest):
         print rack.id
         print rack.nodes[0].id
         self.assertEqual(rack_json['nodes'][0]['id'],
-                str(rack.nodes[0].id))
+                         str(rack.nodes[0].id))
         self.assertTrue(rack_json['capacities'])
         self.assertEqual(rack_json['capacities'][0]['name'],
-                rack.capacities[0].name)
+                         rack.capacities[0].name)
         self.assertEqual(rack_json['capacities'][0]['value'],
-                rack.capacities[0].value)
+                         rack.capacities[0].value)
         self.assertTrue(rack_json['links'])
         self.assertEqual(rack_json['links'][0]['rel'], 'self')
         self.assertEqual(rack_json['links'][0]['href'],
-                'http://localhost/v1/racks/' + str(rack.id))
+                         'http://localhost/v1/racks/' + str(rack.id))
 
     def setUp(self):
-        """Create 'test_rack'"""
+        """Create 'test_rack'."""
 
         super(TestRacks, self).setUp()
         self.test_resource_class = None
@@ -74,7 +74,7 @@ class TestRacks(api.FunctionalTest):
 
     def test_it_returns_single_rack(self):
         response = self.get_json('/racks/' + str(self.test_rack.id),
-                expect_errors=True)
+                                 expect_errors=True)
 
         self.assertEqual(response.status_int, 200)
         self.assertEqual(response.content_type, "application/json")
@@ -87,7 +87,7 @@ class TestRacks(api.FunctionalTest):
 
         # The 'test_rack' is present in the racks listing:
         rack_json = filter(lambda r: r['id'] == self.test_rack.id,
-                response.json)
+                           response.json)
         self.assertEqual(len(rack_json), 1)
 
         # And the Rack serialization is correct
@@ -95,10 +95,10 @@ class TestRacks(api.FunctionalTest):
 
     def test_it_updates_rack(self):
         json = {
-                'name': 'test-new-name'
-            }
+            'name': 'test-new-name',
+        }
         response = self.put_json('/racks/' + str(self.test_rack.id),
-                params=json, status=200)
+                                 params=json, status=200)
         self.assertEqual(response.content_type, "application/json")
         self.assertEqual(response.json['name'], json['name'])
         updated_rack = self.db.get_rack(self.test_rack.id)
@@ -106,18 +106,18 @@ class TestRacks(api.FunctionalTest):
 
     def test_it_creates_and_deletes_new_rack(self):
         json = {
-                'name': 'test-rack-create',
-                'subnet': '127.0.0./24',
-                'slots': '10',
-                'location': 'texas',
-                'capacities': [
-                    {'name': 'memory', 'value': '1024'}
-                ],
-                'nodes': [
-                    {'id': '1234567'},
-                    {'id': '7891011'}
-                ]
-               }
+            'name': 'test-rack-create',
+            'subnet': '127.0.0./24',
+            'slots': '10',
+            'location': 'texas',
+            'capacities': [
+                {'name': 'memory', 'value': '1024'}
+            ],
+            'nodes': [
+                {'id': '1234567'},
+                {'id': '7891011'}
+            ]
+        }
         response = self.post_json('/racks', params=json, status=201)
         self.assertEqual(response.content_type, "application/json")
 
@@ -136,10 +136,9 @@ class TestRacks(api.FunctionalTest):
 
     def test_it_returns_404_when_getting_unknown_rack(self):
         response = self.get_json('/racks/unknown',
-                expect_errors=True,
-                headers={"Accept":
-                    "application/json"}
-                )
+                                 expect_errors=True,
+                                 headers={"Accept": "application/json"}
+                                 )
 
         self.assertEqual(response.status_int, 404)
 
@@ -148,10 +147,9 @@ class TestRacks(api.FunctionalTest):
     #
     def test_it_returns_404_when_deleting_unknown_rack(self):
         response = self.delete_json('/racks/unknown',
-                expect_errors=True,
-                headers={"Accept":
-                    "application/json"}
-                )
+                                    expect_errors=True,
+                                    headers={"Accept": "application/json"}
+                                    )
 
         self.assertEqual(response.status_int, 404)
 
@@ -190,9 +188,9 @@ class TestResourceClasses(api.FunctionalTest):
     def setUp(self):
         super(TestResourceClasses, self).setUp()
         self.rc = self.db.create_resource_class(v1.ResourceClass(
-                          name='test resource class',
-                          service_type='compute',
-                          ))
+            name='test resource class',
+            service_type='compute',
+        ))
         self.racks = []
 
     def tearDown(self):
@@ -203,8 +201,9 @@ class TestResourceClasses(api.FunctionalTest):
     def setup_racks(self):
         for rack_num in range(1, 4):
             self.racks.append(self.db.create_rack(v1.Rack(
-                        name='rack no. {0}'.format(rack_num),
-                        subnet='192.168.1.{0}/24'.format(rack_num))))
+                name='rack no. {0}'.format(rack_num),
+                subnet='192.168.1.{0}/24'.format(rack_num))
+            ))
 
     def teardown_racks(self):
         for rack in self.racks:


### PR DESCRIPTION
This is changes in code formating and indentation
to comply with pep8 standard.

It follows current setting in tox.ini for pep8 (flake8).

I skipped errors like:
- F821 undefined name
- H302 import only modules

This pull request is first to prepare tuskar for CI (TravisCI)
and for better developer experience as @jistr noted at #47
