### PR TITLE
Heat API configuration refactoring

### DIFF
--- a/etc/tuskar/tuskar.conf.sample
+++ b/etc/tuskar/tuskar.conf.sample
@@ -497,5 +497,12 @@
 # value)
 #connection_trace=false
 
+[heat_keystone]
 
-# Total option count: 100
+# Heat API keystone configuration.
+
+#username = heat
+#password = heat
+#tenant_name = admin
+#auth_url = http://10.34.32.181:35357/v2.0
+#insecure = True

--- a/tuskar/api/controllers/v1.py
+++ b/tuskar/api/controllers/v1.py
@@ -471,9 +471,10 @@ class DataCenterController(rest.RestController):
     overcloud on Triple O
     """
 
-    #@pecan.expose('json')
-    #def index(self):
-    #    return {'message': 'hello'}
+    @pecan.expose('json')
+    def get_all(self):
+        heat = heat_client()
+        return heat.get_stack().to_dict()
 
     @pecan.expose('json')
     def post(self, data):


### PR DESCRIPTION
All settings moved to `tuskar.conf`:

Sample configuration:

```
[heat]

stack_name = overcloud
service_type = orchestration

[heat_keystone]

username = heat
password = heat
tenant_name = admin
auth_url = http://10.34.32.181:35357/v2.0
insecure = True
```
