### PR TITLE
Fix regression caused by the pep8 patch

### DIFF
--- a/tuskar/api/controllers/v1.py
+++ b/tuskar/api/controllers/v1.py
@@ -294,6 +294,7 @@ class RacksController(rest.RestController):
             links = [_make_link('self', pecan.request.host_url, 'racks',
                                 rack.id)]
             result.append(Rack.convert_with_links(rack, links))
+
         return result
 
     @wsme_pecan.wsexpose(Rack, unicode)
@@ -361,6 +362,7 @@ class FlavorsController(rest.RestController):
         flavors = []
         for flavor in pecan.request.dbapi.get_flavors(resource_class_id):
             flavors.append(Flavor.add_capacities(resource_class_id, flavor))
+            
         return flavors
         #return [Flavor.from_db_model(flavor) for flavor in result]
 
@@ -442,6 +444,7 @@ class ResourceClassesController(rest.RestController):
         result = []
         for rc in pecan.request.dbapi.get_resource_classes(None):
             result.append(ResourceClass.convert(rc, pecan.request.host_url))
+
         return result
 
     @wsme_pecan.wsexpose(ResourceClass, unicode)


### PR DESCRIPTION
There were 3 wrongly indented return statements introduced in pep8
pull request [1], 2 of them were already fixed, this commit fixes the
third one.

[1] https://github.com/tuskar/tuskar/pull/52
