### PR TITLE
Heat creds

### DIFF
--- a/tuskar/heat/client.py
+++ b/tuskar/heat/client.py
@@ -83,7 +83,9 @@ class HeatClient(object):
                     service_type=CONF.heat['service_type'],
                     endpoint_type=CONF.heat['endpoint_type'])
             self.connection = heatclient(endpoint=endpoint,
-                                         token=keystone.auth_token)
+                                         token=keystone.auth_token,
+                                         username=CONF.heat_keystone['username'],
+                                         password=CONF.heat_keystone['password'])
         except Exception as e:
             LOG.exception(e)
             self.connection = None


### PR DESCRIPTION
There is an issue in HEAT that requires us to pass the username and password in addition to the token.  There for I have added this to the HEAT client.  See link below for info.

https://blueprints.launchpad.net/heat/+spec/auth-token-only
