### PR TITLE
Fixed displaying 'unit' attribute for Rack capacities

### DIFF
--- a/tuskar/api/controllers/v1.py
+++ b/tuskar/api/controllers/v1.py
@@ -162,7 +162,7 @@ class Rack(Base):
                             rack.resource_class_id)]
             self.resource_class = Relation(id=rack.resource_class_id, links=l)
 
-        capacities = [Capacity(name=c.name, value=c.value)
+        capacities = [Capacity(name=c.name, value=c.value, unit=c.unit)
                       for c in rack.capacities]
 
         nodes = [Node(id=n.node_id,

--- a/tuskar/db/sqlalchemy/api.py
+++ b/tuskar/db/sqlalchemy/api.py
@@ -335,7 +335,8 @@ class Connection(api.Connection):
                 [session.delete(c) for c in rack.capacities]
 
                 for c in new_rack.capacities:
-                    capacity = models.Capacity(name=c.name, value=c.value)
+                    capacity = models.Capacity(name=c.name, value=c.value,
+                            unit=c.unit)
                     session.add(capacity)
                     rack.capacities.append(capacity)
                     session.add(rack)
@@ -384,7 +385,8 @@ class Connection(api.Connection):
 
             if new_rack.capacities:
                 for c in new_rack.capacities:
-                    capacity = models.Capacity(name=c.name, value=c.value)
+                    capacity = models.Capacity(name=c.name, value=c.value,
+                            unit=c.unit)
                     session.add(capacity)
                     rack.capacities.append(capacity)
                     session.add(rack)

--- a/tuskar/tests/test_v1.py
+++ b/tuskar/tests/test_v1.py
@@ -49,7 +49,8 @@ class TestRacks(api.FunctionalTest):
                     subnet='10.0.0.0/24',
                     location='nevada',
                     chassis=v1.Chassis(id='123'),
-                    capacities=[v1.Capacity(name='cpu', value='10')],
+                    capacities=[v1.Capacity(name='cpu', value='10',
+                        unit='count')],
                     nodes=[v1.Node(id='1')]
                     ))
         # FIXME: For some reason the 'self.test_rack' does not
@@ -111,7 +112,7 @@ class TestRacks(api.FunctionalTest):
             'slots': '10',
             'location': 'texas',
             'capacities': [
-                {'name': 'memory', 'value': '1024'}
+                {'name': 'memory', 'value': '1024', 'unit': 'MB'}
             ],
             'nodes': [
                 {'id': '1234567'},
@@ -130,6 +131,8 @@ class TestRacks(api.FunctionalTest):
         self.assertEqual(str(response.json['location']), json['location'])
         self.assertEqual(response.json['subnet'], json['subnet'])
         self.assertEqual(len(response.json['nodes']), 2)
+        print dict(response.json['capacities'][0])
+        self.assertEqual(str(response.json['capacities'][0]['unit']), 'MB')
 
         # Make sure we delete the Rack we just created
         self.db.delete_rack(response.json['id'])


### PR DESCRIPTION
NOTE: You **need** to re-run the the sample_data.py script.

This should fix the https://github.com/tuskar/tuskar/issues/72
