### PR TITLE
Heat template flavors aggregates etc

### DIFF
--- a/tuskar/api/controllers/v1.py
+++ b/tuskar/api/controllers/v1.py
@@ -334,7 +334,7 @@ class RacksController(rest.RestController):
 class FlavorsController(rest.RestController):
     """REST controller for Flavor."""
 
-    nova=NovaClient()
+    #nova=NovaClient()
 
     #POST /api/resource_classes/1/flavors
     @wsme.validate(Flavor)
@@ -344,9 +344,9 @@ class FlavorsController(rest.RestController):
         try:
             flavor = pecan.request.dbapi.create_resource_class_flavor(
                                             resource_class_id,flavor)
-            nova_flavor_uuid =  self.nova.create_flavor(flavor,
-                pecan.request.dbapi.get_resource_class(resource_class_id).name)
-            pecan.request.dbapi.update_flavor_nova_uuid(flavor.id, nova_flavor_uuid)
+            #nova_flavor_uuid =  self.nova.create_flavor(flavor,
+                #pecan.request.dbapi.get_resource_class(resource_class_id).name)
+            #pecan.request.dbapi.update_flavor_nova_uuid(flavor.id, nova_flavor_uuid)
         except Exception as e:
             LOG.exception(e)
             raise wsme.exc.ClientSideError(_("Invalid data"))
@@ -388,8 +388,9 @@ class FlavorsController(rest.RestController):
     def delete(self, resource_class_id, flavor_id):
         """Delete a Flavor."""
         #pecan.response.status_code = 204
-        nova_flavor_uuid = pecan.request.dbapi.delete_flavor(flavor_id)
-        self.nova.delete_flavor(nova_flavor_uuid)
+        #nova_flavor_uuid = pecan.request.dbapi.delete_flavor(flavor_id)
+        pecan.request.dbapi.delete_flavor(flavor_id)
+        #self.nova.delete_flavor(nova_flavor_uuid)
 
 
 class ResourceClassesController(rest.RestController):
@@ -403,10 +404,10 @@ class ResourceClassesController(rest.RestController):
         """Create a new Resource Class."""
         try:
             result = pecan.request.dbapi.create_resource_class(resource_class)
-            #create any flavors included in this resource_class creation
-            for flav in result.flavors:
-                nova_flavor_uuid = self.flavors.nova.create_flavor(flav, result.name)
-                pecan.request.dbapi.update_flavor_nova_uuid(flav.id, nova_flavor_uuid)
+            #create in nova any flavors included in this resource_class creation
+            #for flav in result.flavors:
+                #nova_flavor_uuid = self.flavors.nova.create_flavor(flav, result.name)
+                #pecan.request.dbapi.update_flavor_nova_uuid(flav.id, nova_flavor_uuid)
         except Exception as e:
             LOG.exception(e)
             raise wsme.exc.ClientSideError(_("Invalid data"))
@@ -461,9 +462,9 @@ class ResourceClassesController(rest.RestController):
         # TODO(mfojtik): Update the HEAT template at this point
         #
         #DELETE any resource class flavors from nova too
-        for flav in pecan.request.dbapi.get_flavors(resource_class_id):
-            nova_flavor_uuid = pecan.request.dbapi.delete_flavor(flav.id)
-            self.flavors.nova.delete_flavor(nova_flavor_uuid)
+        #for flav in pecan.request.dbapi.get_flavors(resource_class_id):
+        #    nova_flavor_uuid = pecan.request.dbapi.delete_flavor(flav.id)
+        #    self.flavors.nova.delete_flavor(nova_flavor_uuid)
         pecan.request.dbapi.delete_resource_class(resource_class_id)
 
 

--- a/tuskar/api/controllers/v1.py
+++ b/tuskar/api/controllers/v1.py
@@ -362,7 +362,7 @@ class FlavorsController(rest.RestController):
         flavors = []
         for flavor in pecan.request.dbapi.get_flavors(resource_class_id):
             flavors.append(Flavor.add_capacities(resource_class_id, flavor))
-            
+
         return flavors
         #return [Flavor.from_db_model(flavor) for flavor in result]
 
@@ -481,19 +481,21 @@ class DataCenterController(rest.RestController):
     @pecan.expose()
     def template(self):
         rcs = pecan.request.dbapi.get_heat_data()
+        nova_utils = NovaClient()
         return render('overcloud.yaml', dict(resource_classes=rcs,
-            config=CONF))
+           nova_util=nova_utils))
 
     @pecan.expose('json')
-    def post(self, data):
+    def post(self):
         # TODO: Currently all Heat parameters are hardcoded in
         #       template.
         params = {}
         rcs = pecan.request.dbapi.get_heat_data()
         heat = heat_client()
+        nova_utils = NovaClient()
 
         template_body = render('overcloud.yaml', dict(resource_classes=rcs,
-            config=CONF))
+            nova_util=nova_utils))
         if heat.validate_template(template_body):
 
             if heat.exists_stack():

--- a/tuskar/api/templates/compute.yaml
+++ b/tuskar/api/templates/compute.yaml
@@ -88,19 +88,31 @@
           |
           #!/bin/bash -v
           /opt/aws/bin/cfn-init
-          # Setup the keystone:
-          # FIXME: Add OS_USERNAME, OS_PASSWORD, OS_AUTH_URL, etc here with
-          # valid credentials (config.nova_keystone... ?)
-          #
-          # FIXME: List just 'compute' resource classes here?
-      % for rc in resource_classes:
-        % for f in rc.flavors:
-          nova-manage instance_type list compute.${f.name} &> /dev/null
-          if [ $? == 1 ]; then
-            nova-manage instance_type create compute.${f.name} 32768 16 320 0 0 0 # FIXME: Add f.cpus / etc here
-          fi
-        % endfor
-      % endfor
-
+          #0. SOURCE CREDENTIALS FOR NOVA COMMANDS
+          source /root/stackrc
+          % for rc in resource_classes:
+          #1. CREAT HOST AGGREGATE for each resource class
+            AGGREGATE_ID=$(nova aggregate-create "${rc.name}-hosts" | tail -n +4 | head -n 1 | tr -s ' ' | cut -d '|' -f2)
+            #2. SET HOST AGGREGATE METADATA
+            nova aggregate-set-metadata $AGGREGATE_ID class="${rc.name}"
+            #3. CREATE EACH FLAVOR
+            % for f in rc.flavors:
+              nova flavor-show "${rc.name}.${f.name}" &> /dev/null
+              if [ $? == 1 ]; then
+              <%
+                ram, vcpu, disk, ephemeral, swap = nova_util.extract_from_capacities(f)
+              %>
+                nova flavor-create --ephemeral=${ephemeral} --swap=${swap} "${rc.name}.${f.name}" "auto" ${ram} ${disk} ${vcpu}
+              fi
+              #4. SET FLAVOR METADATA
+              nova flavor-key "${rc.name}.${f.name}" set class="${rc.name}"
+            % endfor
+            #5. ADD NODES TO HOST AGGREGATE
+            % for rack in rc.racks:
+              % for node in rack.nodes:
+                nova aggregate-add-host $AGGREGATE_ID ${node.node_id}
+              % endfor
+            % endfor
+          % endfor
     Type: AWS::EC2::Instance
 </%def>\

--- a/tuskar/api/templates/overcloud.yaml
+++ b/tuskar/api/templates/overcloud.yaml
@@ -1,7 +1,7 @@
 <%namespace name="not_compute" file="not_compute.yaml"/>\
 <%namespace name="compute" file="compute.yaml"/>\
 <% # Mapping between resource class service type and a HEAT template
-   # TODO (mtaylor) Move this into Config file or add to model via API call. 
+   # TODO (mtaylor) Move this into Config file or add to model via API call.
    templates = {"compute": compute, "not_compute": not_compute} %>\
 Description: Nova API,Keystone,Heat Engine and API,Glance,Neutron,Dedicated MySQL
   server,Dedicated RabbitMQ Server,Group of Nova Computes

--- a/tuskar/compute/nova.py
+++ b/tuskar/compute/nova.py
@@ -58,7 +58,7 @@ class NovaClient(object):
     #returns newly created flavor uuid from nova
     def create_flavor(self, flavor_data, rc_name):
         try:
-            ram, cpu, disk = self.__extract_from_capacities(flavor_data)
+            ram, cpu, disk, ephemeral, swap = self.extract_from_capacities(flavor_data)
             name = "%s.%s" %(rc_name, flavor_data.name)
             nova_flavor = self.nova_client.flavors.create(name, ram, cpu, disk)
             return nova_flavor.id
@@ -80,14 +80,18 @@ class NovaClient(object):
                 raise
         return True
 
-    def __extract_from_capacities(self, flavor_data):
-        ram = cpu = disk = ""
+    def extract_from_capacities(self, flavor_data):
+        ram = cpu = root_disk = ephemeral = swap = 0
         for c in flavor_data.capacities:
-            if c.name == "memory":
+            if c.name in ["memory", "ram"]:
                 ram = c.value
-            elif c.name == "cpu":
+            elif c.name in ["cpu", "vcpu"]:
                 cpu = c.value
-            elif c.name == "storage":
-                disk = c.value
-        return ram, cpu, disk
+            elif c.name in ["storage", "root_disk"]:
+                root_disk = c.value
+            elif c.name in ["ephemeral_disk", "ephemeral"]:
+                ephemeral = c.value
+            elif c.name in ["swap", "swap_disk"]:
+                swap = c.value
+        return ram, cpu, root_disk, ephemeral, swap
 


### PR DESCRIPTION
This will generate the HEAT template including all the nova commands for:  
- create host aggregate for each resource class  
- tag the host aggregate with the metadata (class=m1)  
- add all nodes in each rack of the resource class to that host aggregate  
- create each flavor, and add metadata (class=m1)  

This is explained in more detail in https://www.pivotaltracker.com/story/show/53809435

To see the HEAT template do:                                               

```
GET http://0.0.0.0:6385/v1/data_centers/template                       
(DO NOT specify Accept header)                                         
```

Second commit removes the calls out to nova for creating flavors, as this is done in the HEAT template now.

Ready for testing against HEAT (POST /data_centers)                        

marios

fwiw - relevant part of generated template looks like:                     

```
  UserData:                                                            
    Fn::Base64:                                                        
      |                                                                
      #!/bin/bash -v                                                   
      /opt/aws/bin/cfn-init                                            
    #0. SOURCE CREDENTIALS FOR NOVA COMMANDS                           
      source /root/stackrc                                             
    #1. CREAT HOST AGGREGATE for each resource class                   
    AGGREGATE_ID=$(nova aggregate-create "compute-rc-hosts" | tail -n +4 | head -n 1 | tr -s ' ' | cut -d '|' -f2)
    #2. SET HOST AGGREGATE METADATA                                    
    nova aggregate-set-metadata $AGGREGATE_ID class="compute-rc"       
    #3. CREATE EACH FLAVOR                                             
      nova flavor-show "compute-rc.m1.xlarge" &> /dev/null             
      if [ $? == 1 ]; then                                             

        nova flavor-create --ephemeral=0 --swap=0 "compute-rc.m1.xlarge" "auto" 15 1680 4
      fi                                                               
    #4. SET FLAVOR METADATA                                            
      nova flavor-key "compute-rc.m1.xlarge" set class="compute-rc"    
    #5. ADD NODES TO HOST AGGREGATE                                    
        nova aggregate-add-host $AGGREGATE_ID 16cfc99b-77ac-4206-a51a-b50420a7bde3
        nova aggregate-add-host $AGGREGATE_ID af1fc886-6166-468c-995f-9f0e234709e9
        nova aggregate-add-host $AGGREGATE_ID 57c8c306-6f40-4ec6-9d4a-6a76ddb2cc93
        nova aggregate-add-host $AGGREGATE_ID 45c9f447-fd93-4f6c-a2ac-af811b2abda2
        nova aggregate-add-host $AGGREGATE_ID a1624c55-6fb4-4a34-a864-4bf06ca4016d
        nova aggregate-add-host $AGGREGATE_ID bc6ed43e-243a-46ec-b1f8-78f78580439d
Type: AWS::EC2::Instance                                               
```
