### PR TITLE
Added possiblity to update the Rack state

### DIFF
--- a/tuskar/db/sqlalchemy/api.py
+++ b/tuskar/db/sqlalchemy/api.py
@@ -317,6 +317,10 @@ class Connection(api.Connection):
             if new_rack.chassis:
                 rack.chassis_id = new_rack.chassis.id
 
+            if new_rack.state and new_rack.state in ['provisioned',
+                    'unprovisioned', 'provisioning', 'error']:
+                    rack.state = new_rack.state
+
             if not isinstance(new_rack.resource_class, wtypes.UnsetType):
                 rc = self.get_resource_class(new_rack.resource_class.get_id())
                 if rack.resource_class_id != rc.id:

--- a/tuskar/tests/test_v1.py
+++ b/tuskar/tests/test_v1.py
@@ -96,7 +96,7 @@ class TestRacks(api.FunctionalTest):
 
     def test_it_updates_rack(self):
         json = {
-            'name': 'test-new-name',
+            'name': 'blabla',
         }
         response = self.put_json('/racks/' + str(self.test_rack.id),
                                  params=json, status=200)
@@ -104,6 +104,28 @@ class TestRacks(api.FunctionalTest):
         self.assertEqual(response.json['name'], json['name'])
         updated_rack = self.db.get_rack(self.test_rack.id)
         self.assertEqual(updated_rack.name, json['name'])
+
+    def test_it_allow_to_update_rack_state(self):
+        json = {
+            'state': 'provisioned',
+        }
+        response = self.put_json('/racks/' + str(self.test_rack.id),
+                                 params=json, status=200)
+        self.assertEqual(response.content_type, "application/json")
+        self.assertEqual(response.json['state'], json['state'])
+        updated_rack = self.db.get_rack(self.test_rack.id)
+        self.assertEqual(updated_rack.state, json['state'])
+
+    def test_it_not_allow_to_update_rack_state_with_unknown_state(self):
+        json = {
+            'state': 'trololo',
+        }
+        response = self.put_json('/racks/' + str(self.test_rack.id),
+                                 params=json, status=200)
+        self.assertEqual(response.content_type, "application/json")
+        self.assertNotEqual(response.json['state'], json['state'])
+        updated_rack = self.db.get_rack(self.test_rack.id)
+        self.assertNotEqual(updated_rack.state, json['state'])
 
     def test_it_creates_and_deletes_new_rack(self):
         json = {


### PR DESCRIPTION
NOTE: This patch will not allow to set the Rack state
when creating a new Rack. The Rack must exists in order to update the state.
