### PR TITLE
Implements PUT /api/resource_classes/ID to update the Flavors

### DIFF
--- a/tuskar/db/sqlalchemy/api.py
+++ b/tuskar/db/sqlalchemy/api.py
@@ -196,6 +196,18 @@ class Connection(api.Connection):
                     rc.racks.append(rack)
                     session.add(rc)
 
+               #Deal with Flavors here - don't need to follow approach above
+               #for Racks, since Flavor cannot be referenced (i.e. exist)
+               #outside a ResourceClass. So can just delete
+            if not isinstance(new_resource_class.flavors, wtypes.UnsetType):
+                #first delete all old flavors
+                [session.delete(old_flavor) for old_flavor in rc.flavors]
+                #now add all the new flavors
+                for new_flav in new_resource_class.flavors:
+                    flavor = self.create_flavor(new_flav)
+                    session.add(flavor)
+                    flavor.resource_class = rc
+
         except Exception:
             session.rollback()
             raise

--- a/tuskar/db/sqlalchemy/models.py
+++ b/tuskar/db/sqlalchemy/models.py
@@ -177,5 +177,5 @@ class ResourceClass(Base):
     flavors = relationship("Flavor",
                            backref="resource_class",
                            lazy='joined',
-                           cascade="all",
+                           cascade="all, delete",
                            passive_updates=False)


### PR DESCRIPTION
This will delete all existing flavors and replace them with those in the
PUT body. Addresses https://github.com/tuskar/tuskar/issues/50

Testing please :)

If you run python sample_data.py - then you can test with:

```
PUT http://0.0.0.0:6385/v1/resource_classes/1

{
    "service_type": "foo",
    "name": "test-foo",
           "flavors": [
                { "name" : "foo",
                  "capacities" : [
                     {   "name": "cpu", 
                         "value" : "1",
                          "unit" : "count" }, 
                     {   "name": "memory",
                         "value" : "1",
                         "unit" : "MiB" },
                     {   "name": "storage", 
                         "value" : "1",
                         "unit" : "GiB" }
                  ]
                }
           ]
}
```
