### PR TITLE
Changes travis test command to tox with envs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: python
 python:
   - 2.7
-install:
-  - pip install -q -r requirements.txt --use-mirrors
-  - pip install -q -r test-requirements.txt --use-mirrors
+env:
+  - TOX_ENV=py27
+  - TOX_ENV=pep8
+before_install:
+  - pip install tox --use-mirrors
 script:
-  - python setup.py testr
+  - tox -e $TOX_ENV
 notifications:
   irc:
     channels:


### PR DESCRIPTION
This changes travis command for test to tox -e TOX_ENV
and sets up travis environments to TOX_ENV=py27
and TOX_ENV=pep8.

This way travis will run both tests on python 2.7
and will check if code is ok by pep8.

Another benefit is that we now have only one place to define
tests and pep8 options - tox.ini

It also commands travis to install tox first.
