### PR TITLE
Add trailing * to .coverage to .gitgnore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ develop-eggs
 .tox
 .venv
 .*.swp
-.coverage
+.coverage*
 cover
 AUTHORS
 ChangeLog


### PR DESCRIPTION
Adds tags and trailing \* to .coverage to .gitgnore
This just add some files into .gitgnore file.
