### PR TITLE
Removes python version from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: python
-python:
-  - 2.7
 env:
   - TOX_ENV=py27
   - TOX_ENV=pep8


### PR DESCRIPTION
This remove specification of python version from .travis.yml.
We do not need it b/c we use travis environments and we use TOX_ENV
variable in them - and this is the place where we are overriding python
version from default travis env.
