### PR TITLE
Adds H302 pep8/hacking error to ignore list

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,7 @@ commands =
 commands = {posargs}
 
 [flake8]
-ignore = E12
+# H302 import only modules.
+ignore = E12,H302
 builtins = _
 exclude =  .venv,.git,.tox,dist,doc,*openstack/common*,*lib/python*,*egg,build,tools


### PR DESCRIPTION
Adds H302 import only modules pep8/hacking error to list ignored by
pep8/flake8 commands - in tox.ini config file.

This is decided solution - see #106
